### PR TITLE
Properties/Scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @baywet @ddyett @MichaelMainer @nikithauc @zengin @ramsessanchez

--- a/.gitignore
+++ b/.gitignore
@@ -350,5 +350,3 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
-
-gradle.properties

--- a/components/abstractions/gradle.properties
+++ b/components/abstractions/gradle.properties
@@ -1,0 +1,41 @@
+# IDE users:
+# Settings specified in this file will override any Gradle settings
+# configured through the IDE.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m
+# org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+
+# The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
+## linux requires 10G, OSX requires 11G
+org.gradle.jvmargs=-Xmx2g
+org.gradle.parallel=true
+org.gradle.caching=true
+
+mavenGroupId         = com.microsoft.graph
+mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenMajorVersion = 0
+mavenMinorVersion = 0
+mavenPatchVersion = [PLACEHOLDER]
+mavenArtifactSuffix = 
+
+#These values are used to run functional tests
+#If you wish to run the functional tests, edit the gradle.properties
+#file in your user directory instead of adding them here.
+#ex: C:\Users\username\.gradle\gradle.properties
+ClientId="CLIENT_ID"
+Username="USERNAME"
+Password="PASSWORD"
+
+#enable mavenCentralPublishingEnabled to publish to maven central
+mavenCentralSnapshotArtifactSuffix = -SNAPSHOT
+mavenCentralPublishingEnabled=false

--- a/components/abstractions/gradle.properties
+++ b/components/abstractions/gradle.properties
@@ -22,10 +22,10 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 mavenGroupId         = com.microsoft.kiota
-mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenArtifactId      = microsoft-kiota-abstractions
 mavenMajorVersion = 0
 mavenMinorVersion = 0
-mavenPatchVersion = [PLACEHOLDER]
+mavenPatchVersion = 1
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/components/abstractions/gradle.properties
+++ b/components/abstractions/gradle.properties
@@ -21,7 +21,7 @@ org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.caching=true
 
-mavenGroupId         = com.microsoft.graph
+mavenGroupId         = com.microsoft.kiota
 mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
 mavenMajorVersion = 0
 mavenMinorVersion = 0

--- a/components/authentication/azure/gradle.properties
+++ b/components/authentication/azure/gradle.properties
@@ -21,11 +21,11 @@ org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.caching=true
 
-mavenGroupId         = com.microsoft.graph
-mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenGroupId         = com.microsoft.kiota
+mavenArtifactId      = microsoft-kiota-authentication-azure
 mavenMajorVersion = 0
 mavenMinorVersion = 0
-mavenPatchVersion = [PLACEHOLDER]
+mavenPatchVersion = 1
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/components/authentication/azure/gradle.properties
+++ b/components/authentication/azure/gradle.properties
@@ -1,0 +1,41 @@
+# IDE users:
+# Settings specified in this file will override any Gradle settings
+# configured through the IDE.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m
+# org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+
+# The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
+## linux requires 10G, OSX requires 11G
+org.gradle.jvmargs=-Xmx2g
+org.gradle.parallel=true
+org.gradle.caching=true
+
+mavenGroupId         = com.microsoft.graph
+mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenMajorVersion = 0
+mavenMinorVersion = 0
+mavenPatchVersion = [PLACEHOLDER]
+mavenArtifactSuffix = 
+
+#These values are used to run functional tests
+#If you wish to run the functional tests, edit the gradle.properties
+#file in your user directory instead of adding them here.
+#ex: C:\Users\username\.gradle\gradle.properties
+ClientId="CLIENT_ID"
+Username="USERNAME"
+Password="PASSWORD"
+
+#enable mavenCentralPublishingEnabled to publish to maven central
+mavenCentralSnapshotArtifactSuffix = -SNAPSHOT
+mavenCentralPublishingEnabled=false

--- a/components/http/okHttp/gradle.properties
+++ b/components/http/okHttp/gradle.properties
@@ -21,11 +21,11 @@ org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.caching=true
 
-mavenGroupId         = com.microsoft.graph
-mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenGroupId         = com.microsoft.kiota
+mavenArtifactId      = microsoft-kiota-serialization-json
 mavenMajorVersion = 0
 mavenMinorVersion = 0
-mavenPatchVersion = [PLACEHOLDER]
+mavenPatchVersion = 1
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/components/http/okHttp/gradle.properties
+++ b/components/http/okHttp/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 mavenGroupId         = com.microsoft.kiota
-mavenArtifactId      = microsoft-kiota-serialization-json
+mavenArtifactId      = microsoft-kiota-http-okHttp
 mavenMajorVersion = 0
 mavenMinorVersion = 0
 mavenPatchVersion = 1

--- a/components/http/okHttp/gradle.properties
+++ b/components/http/okHttp/gradle.properties
@@ -1,0 +1,41 @@
+# IDE users:
+# Settings specified in this file will override any Gradle settings
+# configured through the IDE.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m
+# org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+
+# The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
+## linux requires 10G, OSX requires 11G
+org.gradle.jvmargs=-Xmx2g
+org.gradle.parallel=true
+org.gradle.caching=true
+
+mavenGroupId         = com.microsoft.graph
+mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenMajorVersion = 0
+mavenMinorVersion = 0
+mavenPatchVersion = [PLACEHOLDER]
+mavenArtifactSuffix = 
+
+#These values are used to run functional tests
+#If you wish to run the functional tests, edit the gradle.properties
+#file in your user directory instead of adding them here.
+#ex: C:\Users\username\.gradle\gradle.properties
+ClientId="CLIENT_ID"
+Username="USERNAME"
+Password="PASSWORD"
+
+#enable mavenCentralPublishingEnabled to publish to maven central
+mavenCentralSnapshotArtifactSuffix = -SNAPSHOT
+mavenCentralPublishingEnabled=false

--- a/components/serialization/json/gradle.properties
+++ b/components/serialization/json/gradle.properties
@@ -21,11 +21,11 @@ org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.caching=true
 
-mavenGroupId         = com.microsoft.graph
-mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenGroupId         = com.microsoft.kiota
+mavenArtifactId      = microsoft-kiota-http-okHttp
 mavenMajorVersion = 0
 mavenMinorVersion = 0
-mavenPatchVersion = [PLACEHOLDER]
+mavenPatchVersion = 1
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/components/serialization/json/gradle.properties
+++ b/components/serialization/json/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 mavenGroupId         = com.microsoft.kiota
-mavenArtifactId      = microsoft-kiota-http-okHttp
+mavenArtifactId      = microsoft-kiota-serialization-json
 mavenMajorVersion = 0
 mavenMinorVersion = 0
 mavenPatchVersion = 1

--- a/components/serialization/json/gradle.properties
+++ b/components/serialization/json/gradle.properties
@@ -1,0 +1,41 @@
+# IDE users:
+# Settings specified in this file will override any Gradle settings
+# configured through the IDE.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m
+# org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+
+# The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
+## linux requires 10G, OSX requires 11G
+org.gradle.jvmargs=-Xmx2g
+org.gradle.parallel=true
+org.gradle.caching=true
+
+mavenGroupId         = com.microsoft.graph
+mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenMajorVersion = 0
+mavenMinorVersion = 0
+mavenPatchVersion = [PLACEHOLDER]
+mavenArtifactSuffix = 
+
+#These values are used to run functional tests
+#If you wish to run the functional tests, edit the gradle.properties
+#file in your user directory instead of adding them here.
+#ex: C:\Users\username\.gradle\gradle.properties
+ClientId="CLIENT_ID"
+Username="USERNAME"
+Password="PASSWORD"
+
+#enable mavenCentralPublishingEnabled to publish to maven central
+mavenCentralSnapshotArtifactSuffix = -SNAPSHOT
+mavenCentralPublishingEnabled=false

--- a/components/serialization/text/gradle.properties
+++ b/components/serialization/text/gradle.properties
@@ -21,11 +21,11 @@ org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.caching=true
 
-mavenGroupId         = com.microsoft.graph
-mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenGroupId         = com.microsoft.kiota
+mavenArtifactId      = microsoft-kiota-serialization-text
 mavenMajorVersion = 0
 mavenMinorVersion = 0
-mavenPatchVersion = [PLACEHOLDER]
+mavenPatchVersion = 1
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/components/serialization/text/gradle.properties
+++ b/components/serialization/text/gradle.properties
@@ -1,0 +1,41 @@
+# IDE users:
+# Settings specified in this file will override any Gradle settings
+# configured through the IDE.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m
+# org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+
+# The size of the library demands a large amount of RAM to build. Increase as necessary if you get GC errors
+## linux requires 10G, OSX requires 11G
+org.gradle.jvmargs=-Xmx2g
+org.gradle.parallel=true
+org.gradle.caching=true
+
+mavenGroupId         = com.microsoft.graph
+mavenArtifactId      = microsoft-graph-kiota-java-[NAME]
+mavenMajorVersion = 0
+mavenMinorVersion = 0
+mavenPatchVersion = [PLACEHOLDER]
+mavenArtifactSuffix = 
+
+#These values are used to run functional tests
+#If you wish to run the functional tests, edit the gradle.properties
+#file in your user directory instead of adding them here.
+#ex: C:\Users\username\.gradle\gradle.properties
+ClientId="CLIENT_ID"
+Username="USERNAME"
+Password="PASSWORD"
+
+#enable mavenCentralPublishingEnabled to publish to maven central
+mavenCentralSnapshotArtifactSuffix = -SNAPSHOT
+mavenCentralPublishingEnabled=false

--- a/scripts/decodeAndWrite.ps1
+++ b/scripts/decodeAndWrite.ps1
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<# 
+.Synopsis
+    Decode the encoded string and write it to a local file. 
+.Description 
+    Recieves an encoded string value and decodes it using base64. 
+    Write the new decoded string to a local file for later consumption. 
+.Parameter encodedValue
+    The encoded string we wish to decode.
+.Parameter outputPath
+    The file path that we wish to write the decoded value to.  
+#>
+
+Param(
+    [string]$encodedValue , 
+    [string]$outputPath
+)
+
+if($outputPath -eq "" -or $null -eq $outputPath) {
+    Write-Output "Value of Variable: outputPath is Null or Empty. Exiting."
+    Exit 
+}
+if($encodedValue -eq "" -or $null -eq $encodedValue) {
+    Write-Output "Value of Variable: encodedValue is Null of Empty. Exiting."
+    Exit
+}
+
+$decodedValue = [System.Convert]::FromBase64String($encodedValue)
+$targetFullPath = Join-Path $PWD -ChildPath $outputPath
+[System.IO.File]::WriteAllBytes($targetFullPath, $decodedValue)

--- a/scripts/getLatestVersion.ps1
+++ b/scripts/getLatestVersion.ps1
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<# 
+.Synopsis
+    Retrieve the latest version of the library
+.Description 
+    Retrieves the latest version specified in the Gradle.Properties file
+    Uses the retrieved values to update the environment variable VERSION_STRING
+.Parameter propertiesPath
+    The path pointing to the gradle.properties file.
+#>
+
+#We Should always pass in a propertiesPath
+Param(
+    [string]$propertiesPath
+)
+
+#Retrieve the current version from the Gradle.Properties file given the specified path
+if($propertiesPath -eq "" -or $null -eq $propertiesPath) {
+    $propertiesPath = Join-Path -Path $PSScriptRoot -ChildPath "../gradle.properties"
+}
+$file = get-item $propertiesPath
+$findVersions = $file | Select-String -Pattern "mavenMajorVersion" -Context 0,2
+$content = Get-Content $propertiesPath
+
+$lineNumber = $findVersions.LineNumber - 1
+$versionIndex = $content[$lineNumber].IndexOf("=")
+$versionIndex += 2 # skipping =[space]
+$majorVersion = $content[$lineNumber].Substring($versionIndex)
+$lineNumber++
+$minorVersion = $content[$lineNumber].Substring($versionIndex)
+$lineNumber++
+$patchVersion = $content[$lineNumber].Substring($versionIndex)
+$version = "$majorVersion.$minorVersion.$patchVersion"
+
+#Set Task output to create tag
+Write-Output "::set-output name=tag::v${version}"


### PR DESCRIPTION
Adding the Properties and Scripts files.
Added placeholder for patch version, do we begin each of these at version 0.0.1 since these are all being added to a new repo-housing space? Or do we keep the values we have set on the original Kiota repo? 
Not included is the update minor-version script, this will be added with the github workflows once the structure for them is decided. 
