### PR TITLE
Remove Group and Artifact Name from GradleBuild

### DIFF
--- a/components/abstractions/build.gradle
+++ b/components/abstractions/build.gradle
@@ -7,9 +7,6 @@ plugins {
     id 'signing'
 }
 
-group   = 'com.microsoft.kiota'
-version = '0.0.1'
-
 java {
     modularity.inferModulePath = true
     withSourcesJar()


### PR DESCRIPTION
We already have the group and artifact name referenced in the gradle.properties, no need to include it in the build.gradle file since we will not be doing local references to the abstractions component in any of the other components. Instead we will reference the maven snapshot repo in order to use abstractions.