### PR TITLE
Snapshot dependencies

### DIFF
--- a/components/authentication/azure/build.gradle
+++ b/components/authentication/azure/build.gradle
@@ -29,6 +29,7 @@ sourceSets {
 repositories {
     // You can declare any Maven/Ivy/file repository here.
     mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 apply from: "gradle/dependencies.gradle"

--- a/components/authentication/azure/gradle/dependencies.gradle
+++ b/components/authentication/azure/gradle/dependencies.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     api 'com.azure:azure-core:1.28.0'
 
-    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1'
+    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1-SNAPSHOT'
 }

--- a/components/authentication/azure/settings.gradle
+++ b/components/authentication/azure/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'com-microsoft-kiota-authentication'
-includeBuild '../../abstractions'
+rootProject.name = 'com-microsoft-kiota-authentication-azure'

--- a/components/http/okHttp/build.gradle
+++ b/components/http/okHttp/build.gradle
@@ -30,6 +30,7 @@ sourceSets {
 repositories {
     // You can declare any Maven/Ivy/file repository here.
     mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 apply from: "gradle/dependencies.gradle"

--- a/components/http/okHttp/gradle/dependencies.gradle
+++ b/components/http/okHttp/gradle/dependencies.gradle
@@ -12,6 +12,5 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     api 'com.squareup.okhttp3:okhttp:4.9.3'
 
-
-    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1'
+    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1-SNAPSHOT'
 }

--- a/components/http/okHttp/settings.gradle
+++ b/components/http/okHttp/settings.gradle
@@ -1,2 +1,1 @@
-rootProject.name = 'com-microsoft-kiota-http'
-includeBuild '../../abstractions'
+rootProject.name = 'com-microsoft-kiota-http-okHttp'

--- a/components/serialization/json/build.gradle
+++ b/components/serialization/json/build.gradle
@@ -29,6 +29,7 @@ sourceSets {
 repositories {
     // You can declare any Maven/Ivy/file repository here.
     mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 apply from: "gradle/dependencies.gradle"

--- a/components/serialization/json/gradle/dependencies.gradle
+++ b/components/serialization/json/gradle/dependencies.gradle
@@ -9,5 +9,5 @@ dependencies {
     implementation 'com.google.guava:guava:31.1-jre'
     api 'com.google.code.gson:gson:2.9.0'
 
-    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1'
+    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1-SNAPSHOT'
 }

--- a/components/serialization/json/settings.gradle
+++ b/components/serialization/json/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'com-microsoft-kiota-serialization-json'
-includeBuild '../../abstractions'

--- a/components/serialization/text/build.gradle
+++ b/components/serialization/text/build.gradle
@@ -29,6 +29,7 @@ sourceSets {
 repositories {
     // You can declare any Maven/Ivy/file repository here.
     mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 }
 
 apply from: "gradle/dependencies.gradle"

--- a/components/serialization/text/gradle/dependencies.gradle
+++ b/components/serialization/text/gradle/dependencies.gradle
@@ -6,6 +6,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'com.google.guava:guava:31.1-jre'
-    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1'
+    implementation 'com.google.guava:guava:31.1-jre' 
+    
+    implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:0.0.1-SNAPSHOT'
 }

--- a/components/serialization/text/settings.gradle
+++ b/components/serialization/text/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'com-microsoft-kiota-serialization-text'
-includeBuild '../../abstractions'


### PR DESCRIPTION
The serialization, http, auth components now use the snapshot of the abstractions component. No longer do they have a dependency on the local version. 