### PR TITLE
Verifies URL formats

### DIFF
--- a/components/abstractions/CHANGELOG.md
+++ b/components/abstractions/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+## [0.0.2] - 2022-08-11
+
+### Added
+
 - Adds tests to verify DateTime and DateTimeOffsets default to ISO 8601.
 - Adds check to throw IllegalStateException when the baseUrl path parameter is not set.
 
-### Changed
+## [0.0.1] - 2022-06-28
+
+### Added
+
+- Initial release on snapshot feed.

--- a/components/abstractions/CHANGELOG.md
+++ b/components/abstractions/CHANGELOG.md
@@ -9,4 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Adds tests to verify DateTime and DateTimeOffsets default to ISO 8601.
+- Adds check to throw IllegalStateException when the baseUrl path parameter is not set.
+
 ### Changed

--- a/components/abstractions/gradle.properties
+++ b/components/abstractions/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.kiota
 mavenArtifactId      = microsoft-kiota-abstractions
 mavenMajorVersion = 0
 mavenMinorVersion = 0
-mavenPatchVersion = 1
+mavenPatchVersion = 2
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
@@ -49,7 +49,7 @@ public class RequestInformation {
         } else {
             Objects.requireNonNull(urlTemplate);
             Objects.requireNonNull(queryParameters);
-            if(urlTemplate.toLowerCase().contains("{+baseurl}") && !pathParameters.containsKey("baseurl"))
+            if(!pathParameters.containsKey("baseurl") && urlTemplate.toLowerCase().contains("{+baseurl}"))
                 throw new IllegalStateException("PathParameters must contain a value for \"baseurl\" for the url to be built.");
 
             var template = new URITemplate(urlTemplate)

--- a/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
@@ -36,9 +36,10 @@ public class RequestInformation {
     private URI uri;
     /** Gets the URI of the request. 
      * @throws URISyntaxException
+     * @throws IllegalStateException
      */
     @Nullable
-    public URI getUri() throws URISyntaxException {
+    public URI getUri() throws URISyntaxException,IllegalStateException{
         if(uri != null) {
             return uri;
         } else if(pathParameters.containsKey(RAW_URL_KEY) &&
@@ -48,6 +49,9 @@ public class RequestInformation {
         } else {
             Objects.requireNonNull(urlTemplate);
             Objects.requireNonNull(queryParameters);
+            if(urlTemplate.toLowerCase().contains("{+baseurl}") && !pathParameters.containsKey("baseurl"))
+                throw new IllegalStateException("PathParameters must contain a value for \"baseurl\" for the url to be built.");
+
             var template = new URITemplate(urlTemplate)
                             .expandOnly(new HashMap<String, Object>(queryParameters) {{
                                 putAll(pathParameters);

--- a/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
@@ -1,0 +1,78 @@
+package com.microsoft.kiota;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RequestInformationTest {
+    @Test
+    public void ThrowsInvalidOperationExceptionWhenBaseUrlNotSet()
+    {
+        // Arrange as the request builders would
+        final var requestInfo = new RequestInformation();
+        requestInfo.httpMethod= HttpMethod.GET;
+        requestInfo.urlTemplate = "{+baseurl}/users{?%24count}";
+
+        // Assert
+        var exception = assertThrows(IllegalStateException.class, () -> requestInfo.getUri());
+        assertTrue(exception.getMessage().contains("baseurl"));
+    }
+
+    @Test
+    public void BuildsUrlOnProvidedBaseUrl()
+    {
+        // Arrange as the request builders would
+        final var requestInfo = new RequestInformation();
+        requestInfo.httpMethod= HttpMethod.GET;
+        requestInfo.urlTemplate = "{+baseurl}/users{?%24count}";
+
+        // Act
+        requestInfo.pathParameters.put("baseurl","http://localhost");
+
+        // Assert
+        var result = assertDoesNotThrow(() -> requestInfo.getUri());
+        assertEquals("http://localhost/users", result.toString());
+    }
+
+    @Test
+    public void SetsPathParametersOfDateTimeOffsetType()
+    {
+        // Arrange as the request builders would
+        final var requestInfo = new RequestInformation();
+        requestInfo.httpMethod= HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/getDirectRoutingCalls(fromDateTime='{fromDateTime}',toDateTime='{toDateTime}')";
+
+        // Act
+        final OffsetDateTime fromDateTime = OffsetDateTime.of(2022, 8, 1, 0, 0, 0,0, ZoneOffset.of("+00:00"));
+        final OffsetDateTime toDateTime = OffsetDateTime.of(2022, 8, 2, 0, 0, 0,0, ZoneOffset.of("+00:00"));
+        requestInfo.pathParameters.put("fromDateTime", fromDateTime);
+        requestInfo.pathParameters.put("toDateTime", toDateTime);
+
+        // Assert
+        var uriResult = assertDoesNotThrow(() -> requestInfo.getUri());
+        assertTrue(uriResult.toString().contains("fromDateTime='2022-08-01T00%3A00Z'"));
+        assertTrue(uriResult.toString().contains("toDateTime='2022-08-02T00%3A00Z'"));
+    }
+
+    @Test
+    public void SetsPathParametersOfBooleanType()
+    {
+
+        // Arrange as the request builders would
+        final var requestInfo = new RequestInformation();
+        requestInfo.httpMethod= HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/users{?%24count}";
+
+        // Act
+        var count = true;
+        requestInfo.pathParameters.put("%24count", count);
+
+        // Assert
+        var uriResult = assertDoesNotThrow(() -> requestInfo.getUri());
+        assertTrue(uriResult.toString().contains("count=true"));
+    }
+}


### PR DESCRIPTION
This PR is related to https://github.com/microsoft/kiota-abstractions-dotnet/pull/30

It verifies URL formats in the case of boolean and Date path parameters are added to the path parameters collection by adding tests to verify the behaviour.

Changes include
- Adds tests to verify DateTime and DateTimeOffsets default to ISO 8601. 
- Adds check to throw IllegalStateException when the baseUrl path parameter is not set. 