### PR TITLE
Fix for empty query parameter values in Java

### DIFF
--- a/components/abstractions/CHANGELOG.md
+++ b/components/abstractions/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.0.12] - 2023-01-06
+
+### Changed
+
+- Prevent empty values from showing up in query parameters values.
+
 ## [0.0.11] - 2022-12-15
 
 ### Added

--- a/components/abstractions/gradle.properties
+++ b/components/abstractions/gradle.properties
@@ -25,7 +25,7 @@ mavenGroupId         = com.microsoft.kiota
 mavenArtifactId      = microsoft-kiota-abstractions
 mavenMajorVersion = 0
 mavenMinorVersion = 0
-mavenPatchVersion = 11
+mavenPatchVersion = 12
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests

--- a/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
@@ -102,7 +102,7 @@ public class RequestInformation {
                 if(value != null) {
                     if(value.getClass().isArray()) {
                         queryParameters.put(name, Arrays.asList((Object[])value));
-                    } else {
+                    } else if(!value.toString().isEmpty()){
                         queryParameters.put(name, value);
                     }
                 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
@@ -69,6 +69,48 @@ public class RequestInformationTest {
     }
 
     @Test
+    public void DoesNotSetQueryParametersParametersIfEmptyString()
+    {
+
+        // Arrange as the request builders would
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod= HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/users{?%24search}";
+
+        final GetQueryParameters queryParameters = new GetQueryParameters();
+        queryParameters.search = "";
+
+        // Act
+        requestInfo.addQueryParameters(queryParameters);
+
+        // Assert
+        assertEquals("", queryParameters.search);
+        var uriResult = assertDoesNotThrow(() -> requestInfo.getUri());
+        assertFalse(uriResult.toString().contains("search"));
+        
+    }
+
+    @Test
+    public void DoesNotSetQueryParametersParametersIfEmptyCollection()
+    {
+
+        // Arrange as the request builders would
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod= HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/users{?%24select}";
+
+        final GetQueryParameters queryParameters = new GetQueryParameters();
+        queryParameters.select = new String[]{};
+        // Act
+        requestInfo.addQueryParameters(queryParameters);
+
+        // Assert
+        assertTrue(queryParameters.select.length == 0);
+        var uriResult = assertDoesNotThrow(() -> requestInfo.getUri());
+        assertFalse(uriResult.toString().contains("select"));
+    }
+
+    @Test
     public void SetsPathParametersOfBooleanType()
     {
 
@@ -149,4 +191,18 @@ public class RequestInformationTest {
         verify(writerMock, times(1)).writeStringValue(any(), anyString());
         verify(writerMock, never()).writeCollectionOfPrimitiveValues(any(), any(Iterable.class));
     }
+}
+
+
+/// <summary>The messages in a mailbox or folder. Read-only. Nullable.</summary>
+class GetQueryParameters
+{
+    /// <summary>Select properties to be returned</summary>\
+    @QueryParameter(name ="%24select")
+    @javax.annotation.Nullable
+    public String[] select;
+    /// <summary>Search items by search phrases</summary>
+    @QueryParameter(name ="%24search")
+    @javax.annotation.Nullable
+    public String search;
 }


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota-abstractions-dotnet/pull/61

In summary : 

- Adds test to validate.
- Empty collections seem to be already catered for by template library and validated with the existing test.