### PR TITLE
Adds http response code to the api exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.3.1] - 2023-03-08
+
+# Added
+
+- Adds ResponseStatusCode property to API exception class
+
 ## [0.3.0] - 2023-02-21
 
 ### Changed

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiException.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiException.java
@@ -20,4 +20,7 @@ public class ApiException extends Exception {
     public ApiException(@Nonnull final Throwable cause) {
         super(cause);
     }
+
+    /** The HTTP status code  for the response*/
+    public int responseStatusCode;
 }

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -586,6 +586,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
             !(statusCode >= 500 && statusCode < 600 && errorMappings.containsKey("5XX"))) {
 		        spanForAttributes.setAttribute(errorMappingFoundAttributeName, false);
                 final ApiException result = new ApiException("the server returned an unexpected status code and no error class is registered for this code " + statusCode);
+                result.responseStatusCode = statusCode;
                 spanForAttributes.recordException(result);
                 throw result;
             }
@@ -603,6 +604,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
 		            spanForAttributes.setAttribute(errorBodyFoundAttributeName, false);
                     closeResponse = false;
                     final ApiException result = new ApiException("service returned status code" + statusCode + " but no response body was found");
+                    result.responseStatusCode = statusCode;
                     spanForAttributes.recordException(result);
                     throw result;
                 }
@@ -616,6 +618,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                     } else {
                         result = new ApiException("unexpected error type " + error.getClass().getName());
                     }
+                    result.responseStatusCode = statusCode;
                     spanForAttributes.recordException(result);
                     throw result;
                 } finally {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 0
 mavenMinorVersion = 3
-mavenPatchVersion = 0
+mavenPatchVersion = 1
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests


### PR DESCRIPTION
This PR closes https://github.com/microsoft/kiota/issues/2246

It adds the `responseStatusCode` property to the `APIException` class and ensures the request adaptet populates it in case of any error.