### PR TITLE
fix: method POST must have a request body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## [Unreleased]
 
 ### Added
 
 ### Changed
 
-- Fix add an empty body when method is POST and the body is null
+## [0.3.2] - 2023-03-16
+
+### Added
+
+### Changed
+
+- Fix add an empty body when method is POST/PUT/PATCH and the body is null
 
 ## [0.3.1] - 2023-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fix add an empty body when method is POST and the body is null
+
 ## [0.3.1] - 2023-03-08
 
 # Added

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -802,7 +802,10 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                 };
 
             // https://stackoverflow.com/a/35743536
-            if (body == null && requestInfo.httpMethod.equals(HttpMethod.POST)) {
+            if (body == null &&
+                    (requestInfo.httpMethod.equals(HttpMethod.POST) ||
+                     requestInfo.httpMethod.equals(HttpMethod.PATCH) ||
+                     requestInfo.httpMethod.equals(HttpMethod.PUT))) {
                 body = RequestBody.create(new byte[0]);
             }
             final Request.Builder requestBuilder = new Request.Builder()

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 
 import com.microsoft.kiota.ApiClientBuilder;
 import com.microsoft.kiota.ApiException;
+import com.microsoft.kiota.HttpMethod;
 import com.microsoft.kiota.RequestInformation;
 import com.microsoft.kiota.RequestOption;
 import com.microsoft.kiota.ResponseHandlerOption;
@@ -766,7 +767,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
             span.end();
         }
     }
-    private Request getRequestFromRequestInformation(@Nonnull final RequestInformation requestInfo, @Nonnull final Span parentSpan, @Nonnull final Span spanForAttributes) throws URISyntaxException, MalformedURLException {
+    protected Request getRequestFromRequestInformation(@Nonnull final RequestInformation requestInfo, @Nonnull final Span parentSpan, @Nonnull final Span spanForAttributes) throws URISyntaxException, MalformedURLException {
         final Span span = GlobalOpenTelemetry.getTracer(obsOptions.getTracerInstrumentationName()).spanBuilder("getRequestFromRequestInformation").setParent(Context.current().with(parentSpan)).startSpan();
         try(final Scope scope = span.makeCurrent()) {
             spanForAttributes.setAttribute(SemanticAttributes.HTTP_METHOD, requestInfo.httpMethod.toString());
@@ -778,8 +779,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
             spanForAttributes.setAttribute(SemanticAttributes.HTTP_HOST, requestURL.getHost());
             spanForAttributes.setAttribute(SemanticAttributes.HTTP_SCHEME, requestURL.getProtocol());
 
-        
-            final RequestBody body = requestInfo.content == null ? 
+            RequestBody body = requestInfo.content == null ?
                 null :
                 new RequestBody() {
                     @Override
@@ -800,6 +800,11 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                     }
 
                 };
+
+            // https://stackoverflow.com/a/35743536
+            if (body == null && requestInfo.httpMethod.equals(HttpMethod.POST)) {
+                body = RequestBody.create(new byte[0]);
+            }
             final Request.Builder requestBuilder = new Request.Builder()
                                                 .url(requestURL)
                                                 .method(requestInfo.httpMethod.toString(), body);

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -767,7 +767,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
             span.end();
         }
     }
-    protected Request getRequestFromRequestInformation(@Nonnull final RequestInformation requestInfo, @Nonnull final Span parentSpan, @Nonnull final Span spanForAttributes) throws URISyntaxException, MalformedURLException {
+    protected @Nonnull Request getRequestFromRequestInformation(@Nonnull final RequestInformation requestInfo, @Nonnull final Span parentSpan, @Nonnull final Span spanForAttributes) throws URISyntaxException, MalformedURLException {
         final Span span = GlobalOpenTelemetry.getTracer(obsOptions.getTracerInstrumentationName()).spanBuilder("getRequestFromRequestInformation").setParent(Context.current().with(parentSpan)).startSpan();
         try(final Scope scope = span.makeCurrent()) {
             spanForAttributes.setAttribute(SemanticAttributes.HTTP_METHOD, requestInfo.httpMethod.toString());

--- a/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
+++ b/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
@@ -1,7 +1,6 @@
 package com.microsoft.kiota.http;
 
 import static org.junit.jupiter.api.Assertions.*;
-
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -14,7 +13,6 @@ import com.microsoft.kiota.serialization.ParseNode;
 import com.microsoft.kiota.serialization.ParseNodeFactory;
 import com.microsoft.kiota.HttpMethod;
 import com.microsoft.kiota.RequestInformation;
-
 import java.util.concurrent.CompletableFuture;
 import java.io.InputStream;
 import java.io.IOException;

--- a/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
+++ b/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
@@ -6,6 +6,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import com.microsoft.kiota.authentication.AuthenticationProvider;
@@ -42,13 +43,14 @@ import okhttp3.ResponseBody;
 import javax.annotation.Nonnull;
 
 public class OkHttpRequestAdapterTest {
-	@Test
-	public void PostRequestsShouldHaveEmptyBody() throws Exception { // Unexpected exception thrown: java.lang.IllegalArgumentException: method POST must have a request body.
+	@ParameterizedTest
+	@EnumSource(value = HttpMethod.class, names = {"PUT", "POST", "PATCH"})
+	public void PostRequestsShouldHaveEmptyBody(HttpMethod method) throws Exception { // Unexpected exception thrown: java.lang.IllegalArgumentException: method POST must have a request body.
 		final var authenticationProviderMock = mock(AuthenticationProvider.class);
 		final var adapter = new OkHttpRequestAdapter(authenticationProviderMock) {
 			public Request test() throws Exception {
 				var ri = new RequestInformation();
-				ri.httpMethod = HttpMethod.POST;
+				ri.httpMethod = method;
 				ri.urlTemplate = "http://localhost:1234";
 				var span1 = GlobalOpenTelemetry.getTracer("").spanBuilder("").startSpan();
 				var span2 = GlobalOpenTelemetry.getTracer("").spanBuilder("").startSpan();

--- a/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
+++ b/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
@@ -3,8 +3,6 @@ package com.microsoft.kiota.http;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.trace.Span;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -17,8 +15,6 @@ import com.microsoft.kiota.serialization.ParseNodeFactory;
 import com.microsoft.kiota.HttpMethod;
 import com.microsoft.kiota.RequestInformation;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.util.concurrent.CompletableFuture;
 import java.io.InputStream;
 import java.io.IOException;
@@ -39,8 +35,6 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-
-import javax.annotation.Nonnull;
 
 public class OkHttpRequestAdapterTest {
 	@ParameterizedTest


### PR DESCRIPTION
This is a fix for the issue found here:
https://github.com/bf2fc6cc711aee1a0c2a/e2e-test-suite/pull/502#discussion_r1136044789

```
// Unexpected exception thrown: java.lang.IllegalArgumentException: method POST must have a request body.
```
