### PR TITLE
Aligns http client timeout defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.3.3] - 2023-03-20
+
 ### Changed
+
+- Aligns default http client timeout to be 100 seconds
+- Updates the JsonParseNodeFactory to pass a JsonElement using `JsonParser.parseReader` rather than creating a string when creating the root parseNode.
 
 ## [0.3.2] - 2023-03-16
 

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/KiotaClientFactory.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/KiotaClientFactory.java
@@ -2,7 +2,7 @@ package com.microsoft.kiota.http;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
+import java.time.Duration;
 import com.microsoft.kiota.http.middleware.RedirectHandler;
 import com.microsoft.kiota.http.middleware.RetryHandler;
 import com.microsoft.kiota.http.middleware.UserAgentHandler;
@@ -29,7 +29,11 @@ public class KiotaClientFactory {
      */
     @Nonnull
     public static OkHttpClient.Builder create(@Nullable final Interceptor[] interceptors) {
-        final OkHttpClient.Builder builder = new OkHttpClient.Builder(); //TODO configure the default client options.
+        final OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .connectTimeout(Duration.ofSeconds(100))
+                .readTimeout(Duration.ofSeconds(100))
+                .callTimeout(Duration.ofSeconds(100)); //TODO configure the default client options.
+
         final Interceptor[] interceptorsOrDefault = interceptors != null ? interceptors : createDefaultInterceptors();
         for (final Interceptor interceptor : interceptorsOrDefault) {
             builder.addInterceptor(interceptor);

--- a/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
+++ b/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
@@ -30,14 +30,6 @@ public class JsonParseNode implements ParseNode {
     private final JsonElement currentNode;
     /**
      * Creates a new instance of the JsonParseNode class.
-     * @param rawJson the raw json to parse.
-     */
-    public JsonParseNode(@Nonnull final String rawJson) {
-        Objects.requireNonNull(rawJson, "parameter node cannot be null");
-        currentNode = JsonParser.parseString(rawJson);
-    }
-    /**
-     * Creates a new instance of the JsonParseNode class.
      * @param node the node to wrap.
      */
     public JsonParseNode(@Nonnull final JsonElement node) {

--- a/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNodeFactory.java
+++ b/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNodeFactory.java
@@ -1,12 +1,12 @@
 package com.microsoft.kiota.serialization;
 
-import java.io.BufferedReader;
+import com.google.gson.JsonParser;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -31,16 +31,11 @@ public class JsonParseNodeFactory implements ParseNodeFactory {
         } else if (!contentType.equals(validContentType)) {
             throw new IllegalArgumentException("expected a " + validContentType + " content type");
         }
-        String rawText;
         try(final InputStreamReader reader = new InputStreamReader(rawResponse, StandardCharsets.UTF_8)) {
-            try(final BufferedReader buff = new BufferedReader(reader)) {
-                rawText = buff.lines()
-                .collect(Collectors.joining("\n"));
-            }
+            return new JsonParseNode(JsonParser.parseReader(reader));
         } catch (IOException ex) {
             throw new RuntimeException("could not close the reader", ex);
         }
-        return new JsonParseNode(rawText);
     }
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 0
 mavenMinorVersion = 3
-mavenPatchVersion = 2
+mavenPatchVersion = 3
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests


### PR DESCRIPTION
This PR aligns the default timeout for the default client to 100 seconds.

It also closes https://github.com/microsoft/kiota-java/issues/221 by removing the String constructor for `JsonParseNode` and leaves the creating of `JsonElement` to the caller and updates the JsonParseNodeFactory to pass a JsonElement using `JsonParser.parseReader` rather than creating a string when creating the root parseNode.