### PR TITLE
#585 Prevent decoding of parameter values in the ParametersNameDecodingHandler Interceptor & write corresponding test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.7.3] - 2023-09-04
+
+### Fixed
+
+- Fixed bug that caused the ParametersNameDecodingHandler to decode query parameter values in addition to names
+
 ## [0.7.2] - 2023-09-01
 
 ### Changed

--- a/components/http/okHttp/src/test/java/com/microsoft/kiota/http/ParametersNameDecodingHandlerTest.java
+++ b/components/http/okHttp/src/test/java/com/microsoft/kiota/http/ParametersNameDecodingHandlerTest.java
@@ -1,0 +1,50 @@
+package com.microsoft.kiota.http;
+
+import com.microsoft.kiota.http.middleware.ParametersNameDecodingHandler;
+import com.microsoft.kiota.http.middleware.options.ParametersNameDecodingOption;
+
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ParametersNameDecodingHandlerTest {
+    
+    private static Stream<Arguments> originalAndExpectedUrls() {
+        return Stream.of(
+                Arguments.of("https://www.google.com/", "https://www.google.com/"),
+                Arguments.of("https://www.google.com/?q=1%2B2", "https://www.google.com/?q=1%2B2"),
+                Arguments.of("https://www.google.com/?q=M%26A", "https://www.google.com/?q=M%26A"),
+                Arguments.of("https://www.google.com/?q%2D1=M%26A", "https://www.google.com/?q-1=M%26A"),
+                Arguments.of("https://www.google.com/?q%2D1&q=M%26A=M%26A", "https://www.google.com/?q-1&q=M%26A=M%26A")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("originalAndExpectedUrls")
+    public void defaultParameterNameDecodingHandlerOnlyDecodesNamesNotValues(String original, String expectedResult) throws IOException {
+        Interceptor[] interceptors = new Interceptor[] {
+                new ParametersNameDecodingHandler( new ParametersNameDecodingOption() {
+                    {
+                        parametersToDecode = new char[] { '$', '.', '-', '~', '+', '&' };
+                    }
+                })
+        };
+        final OkHttpClient client = KiotaClientFactory.create(interceptors).build();
+        final Request request = new Request.Builder().url(original).build();
+        final Response response = client.newCall(request).execute();
+        
+        assertNotNull(response);
+        assertEquals(expectedResult, response.request().url().toString());
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 0
 mavenMinorVersion = 7
-mavenPatchVersion = 2
+mavenPatchVersion = 3
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests


### PR DESCRIPTION
This pull request fixes #585, ensuring that the ParametersNameDecodingHandler only decodes query parameter names (and not values). I wrote a test case using the problem URLs that were linked in the issue.