### PR TITLE
ApiException mutable field better encapsulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a `tryAdd` method to the `RequestHeaders` Map
 
+### Changed
+
+- Better encapsulation of the mutable field `responseStatusCode` in `ApiException`
+
 ## [0.7.4] - 2023-09-08
 
 ### Fixed

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiException.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiException.java
@@ -24,7 +24,25 @@ public class ApiException extends Exception {
     }
 
     /** The HTTP status code  for the response*/
-    public int responseStatusCode;
+    private int responseStatusCode;
+
+    /**
+     * Gets the HTTP response status code
+     * @return The response status code from the failed response.
+     */
+    @Nonnull
+    public int getResponseStatusCode() {
+        return responseStatusCode;
+    }
+
+    /**
+     * Sets the HTTP response status code
+     * @param responseStatusCode The response status code to set.
+     */
+    protected void setResponseStatusCode(int responseStatusCode) {
+        Objects.requireNonNull(responseStatusCode);
+        this.responseStatusCode = responseStatusCode;
+    }
 
     /** The HTTP response headers for the error response*/
     @Nonnull
@@ -43,7 +61,7 @@ public class ApiException extends Exception {
      * Sets the HTTP response headers for the error response
      * @param responseHeaders The response headers collections to set.
      */
-    public void setResponseHeaders(@Nonnull ResponseHeaders responseHeaders) {
+    protected void setResponseHeaders(@Nonnull ResponseHeaders responseHeaders) {
         Objects.requireNonNull(responseHeaders);
         this.responseHeaders = new ResponseHeaders(responseHeaders);
     }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiException.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiException.java
@@ -40,7 +40,6 @@ public class ApiException extends Exception {
      * @param responseStatusCode The response status code to set.
      */
     protected void setResponseStatusCode(int responseStatusCode) {
-        Objects.requireNonNull(responseStatusCode);
         this.responseStatusCode = responseStatusCode;
     }
 

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -29,6 +29,7 @@ public class ApiExceptionBuilder {
      * @param message The message to be attached to this ApiException.
      * @return The builder object.
      */
+    @Nonnull
     public ApiExceptionBuilder withMessage(@Nonnull String message) {
         Objects.requireNonNull(message);
         if (value == null) {
@@ -44,6 +45,7 @@ public class ApiExceptionBuilder {
      * @param exception The Throwable to be used as Cause for this ApiException.
      * @return The builder object.
      */
+    @Nonnull
     public ApiExceptionBuilder withThrowable(@Nonnull Throwable exception) {
         Objects.requireNonNull(exception);
         if (value == null) {
@@ -59,6 +61,7 @@ public class ApiExceptionBuilder {
      * @param responseStatusCode an int representing the response status code.
      * @return The builder object.
      */
+    @Nonnull
     public ApiExceptionBuilder withResponseStatusCode(int responseStatusCode) {
         if (value == null) {
             value = new ApiException();
@@ -72,6 +75,7 @@ public class ApiExceptionBuilder {
      * @param responseHeaders the response headers to be added to this ApiException.
      * @return The builder object.
      */
+    @Nonnull
     public ApiExceptionBuilder withResponseHeaders(@Nonnull ResponseHeaders responseHeaders) {
         if (value == null) {
             value = new ApiException();
@@ -84,6 +88,7 @@ public class ApiExceptionBuilder {
      * Build and return an instance of ApiException
      * @return The built ApiException.
      */
+    @Nonnull
     public ApiException build() {
         ApiException result = value;
         value = null;

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -1,0 +1,51 @@
+package com.microsoft.kiota;
+
+import jakarta.annotation.Nonnull;
+
+import java.util.Objects;
+
+/** Builder class for ApiException. */
+public class ApiExceptionBuilder {
+
+    private ApiException value = null;
+    public ApiExceptionBuilder() {
+    }
+    public ApiExceptionBuilder(ApiException base) {
+        value = base;
+    }
+    public ApiExceptionBuilder withMessage(@Nonnull String message) {
+        Objects.requireNonNull(message);
+        if (value == null) {
+            value = new ApiException(message);
+        } else {
+            value = new ApiException(message, value.getCause());
+        }
+        return this;
+    }
+    public ApiExceptionBuilder withThrowable(@Nonnull Throwable exception) {
+        Objects.requireNonNull(exception);
+        if (value == null) {
+            value = new ApiException(exception);
+        } else {
+            value = new ApiException(value.getMessage(), value.getCause());
+        }
+        return this;
+    }
+    public ApiExceptionBuilder withResponseStatusCode(int responseStatusCode) {
+        if (value == null) {
+            value = new ApiException();
+        }
+        value.setResponseStatusCode(responseStatusCode);
+        return this;
+    }
+    public ApiExceptionBuilder withResponseHeaders(@Nonnull ResponseHeaders responseHeaders) {
+        if (value == null) {
+            value = new ApiException();
+        }
+        value.setResponseHeaders(responseHeaders);
+        return this;
+    }
+    public ApiException build() {
+        return value;
+    }
+}

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -20,7 +20,7 @@ public class ApiExceptionBuilder {
      * @param base The original ApiException to be used as a base.
      */
     public ApiExceptionBuilder(ApiException base) {
-        value = base;
+        value = new ApiException(base.getMessage(), base.getCause());
     }
 
     /**
@@ -84,6 +84,8 @@ public class ApiExceptionBuilder {
      * @return The built ApiException.
      */
     public ApiException build() {
-        return value;
+        ApiException result = value;
+        value = null;
+        return result;
     }
 }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -19,7 +19,8 @@ public class ApiExceptionBuilder {
      * Constructs an ApiExceptionBuilder starting from a base ApiException
      * @param base The original ApiException to be used as a base.
      */
-    public ApiExceptionBuilder(ApiException base) {
+    public ApiExceptionBuilder(@Nonnull final ApiException base) {
+        Objects.requireNonNull(base);
         value = new ApiException(base.getMessage(), base.getCause());
     }
 

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -8,11 +8,24 @@ import java.util.Objects;
 public class ApiExceptionBuilder {
 
     private ApiException value = null;
+
+    /**
+     * Constructs an empty ApiExceptionBuilder
+     */
     public ApiExceptionBuilder() {
     }
+
+    /**
+     * Constructs an ApiExceptionBuilder starting from a base ApiException
+     */
     public ApiExceptionBuilder(ApiException base) {
         value = base;
     }
+
+    /**
+     * Assign the message to the builder
+     * @return The builder object.
+     */
     public ApiExceptionBuilder withMessage(@Nonnull String message) {
         Objects.requireNonNull(message);
         if (value == null) {
@@ -22,6 +35,11 @@ public class ApiExceptionBuilder {
         }
         return this;
     }
+
+    /**
+     * Assign the Throwable cause of the Exception to the builder
+     * @return The builder object.
+     */
     public ApiExceptionBuilder withThrowable(@Nonnull Throwable exception) {
         Objects.requireNonNull(exception);
         if (value == null) {
@@ -31,6 +49,11 @@ public class ApiExceptionBuilder {
         }
         return this;
     }
+
+    /**
+     * Assign the response status code to the builder
+     * @return The builder object.
+     */
     public ApiExceptionBuilder withResponseStatusCode(int responseStatusCode) {
         if (value == null) {
             value = new ApiException();
@@ -38,6 +61,11 @@ public class ApiExceptionBuilder {
         value.setResponseStatusCode(responseStatusCode);
         return this;
     }
+
+    /**
+     * Assign the response headers to the builder
+     * @return The builder object.
+     */
     public ApiExceptionBuilder withResponseHeaders(@Nonnull ResponseHeaders responseHeaders) {
         if (value == null) {
             value = new ApiException();
@@ -45,6 +73,11 @@ public class ApiExceptionBuilder {
         value.setResponseHeaders(responseHeaders);
         return this;
     }
+
+    /**
+     * Build and return an instance of ApiException
+     * @return The built ApiException.
+     */
     public ApiException build() {
         return value;
     }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -17,6 +17,7 @@ public class ApiExceptionBuilder {
 
     /**
      * Constructs an ApiExceptionBuilder starting from a base ApiException
+     * @param base The original ApiException to be used as a base.
      */
     public ApiExceptionBuilder(ApiException base) {
         value = base;
@@ -24,6 +25,7 @@ public class ApiExceptionBuilder {
 
     /**
      * Assign the message to the builder
+     * @param message The message to be attached to this ApiException.
      * @return The builder object.
      */
     public ApiExceptionBuilder withMessage(@Nonnull String message) {
@@ -38,6 +40,7 @@ public class ApiExceptionBuilder {
 
     /**
      * Assign the Throwable cause of the Exception to the builder
+     * @param exception The Throwable to be used as Cause for this ApiException.
      * @return The builder object.
      */
     public ApiExceptionBuilder withThrowable(@Nonnull Throwable exception) {
@@ -52,6 +55,7 @@ public class ApiExceptionBuilder {
 
     /**
      * Assign the response status code to the builder
+     * @param responseStatusCode an int representing the response status code.
      * @return The builder object.
      */
     public ApiExceptionBuilder withResponseStatusCode(int responseStatusCode) {
@@ -64,6 +68,7 @@ public class ApiExceptionBuilder {
 
     /**
      * Assign the response headers to the builder
+     * @param responseHeaders the response headers to be added to this ApiException.
      * @return The builder object.
      */
     public ApiExceptionBuilder withResponseHeaders(@Nonnull ResponseHeaders responseHeaders) {

--- a/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
+++ b/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
@@ -187,7 +187,7 @@ public class OkHttpRequestAdapterTest {
 		final var exception = assertThrows(ExecutionException.class, ()->requestAdapter.sendAsync(requestInformation, (node) -> mockEntity, null).get()) ;
 		final var cause = exception.getCause();	
 		assertTrue(cause instanceof ApiException);
-		assertEquals(404, ((ApiException)cause).responseStatusCode);
+		assertEquals(404, ((ApiException)cause).getResponseStatusCode());
 		assertTrue(((ApiException)cause).getResponseHeaders().containsKey("request-id"));
 	}
 	public static OkHttpClient getMockClient(final Response response) throws IOException {


### PR DESCRIPTION
fixes #654 , using a builder pattern we can better encapsulate the `responseStatusCode` mutable field.

I think it's a code smell to pass to the user-land an object with a mutable field, since we have all of the information to build the final one it should not be exposed to the user.