### PR TITLE
Preserve user errors instead of creating new ApiExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [0.7.8] - 2023-10-13
+
+### Fixed
+
+- Fixed a bug to preserve the user defined error instead of converting it to generic ApiException.
+
 ## [0.7.7] - 2023-10-12
 
 ### Added

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -1,8 +1,11 @@
 package com.microsoft.kiota;
 
+import com.microsoft.kiota.serialization.Parsable;
 import jakarta.annotation.Nonnull;
 
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /** Builder class for ApiException. */
 public class ApiExceptionBuilder {
@@ -17,11 +20,18 @@ public class ApiExceptionBuilder {
 
     /**
      * Constructs an ApiExceptionBuilder starting from a base ApiException
-     * @param base The original ApiException to be used as a base.
+     * @param builder A builder for the ApiException to be used as a base.
      */
-    public ApiExceptionBuilder(@Nonnull final ApiException base) {
-        Objects.requireNonNull(base);
-        value = new ApiException(base.getMessage(), base.getCause());
+    public ApiExceptionBuilder(@Nonnull final Supplier<Parsable> builder) {
+        Objects.requireNonNull(builder);
+        final Parsable error = builder.get();
+        if (error instanceof ApiException) {
+            value = (ApiException) error;
+        } else {
+            value = new ApiExceptionBuilder()
+                    .withMessage("\"unexpected error type \" + error.getClass().getName()")
+                    .build();
+        }
     }
 
     /**

--- a/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/ApiExceptionBuilder.java
@@ -4,7 +4,6 @@ import com.microsoft.kiota.serialization.Parsable;
 import jakarta.annotation.Nonnull;
 
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /** Builder class for ApiException. */

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -625,15 +625,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                 spanForAttributes.setAttribute(errorBodyFoundAttributeName, true);
                 final Span deserializationSpan = GlobalOpenTelemetry.getTracer(obsOptions.getTracerInstrumentationName()).spanBuilder("getObjectValue").setParent(Context.current().with(span)).startSpan();
                 try(final Scope deserializationScope = deserializationSpan.makeCurrent()) {
-                    final Parsable error = rootNode.getObjectValue(errorClass);
-                    ApiExceptionBuilder resultBuilder;
-                    if (error instanceof ApiException) {
-                        resultBuilder = new ApiExceptionBuilder((ApiException)error);
-                    } else {
-                        resultBuilder = new ApiExceptionBuilder()
-                                .withMessage("unexpected error type " + error.getClass().getName());
-                    }
-                    ApiException result = resultBuilder
+                    ApiException result = new ApiExceptionBuilder(() -> rootNode.getObjectValue(errorClass))
                             .withResponseStatusCode(statusCode)
                             .withResponseHeaders(responseHeaders)
                             .build();

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 0
 mavenMinorVersion = 7
-mavenPatchVersion = 7
+mavenPatchVersion = 8
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests


### PR DESCRIPTION
Bug found here: https://github.com/microsoft/kiota/pull/3401#discussion_r1356991436

There was too much to be done to test in this repo, I tested locally against the `kiota` integration tests.