### PR TITLE
Add a Basic Access Authentication Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added a default implementation of `BasicAccessAuthenticationProvider`
+
 ## [0.7.8] - 2023-10-13
 
 ### Fixed

--- a/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
@@ -9,22 +9,28 @@ import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-// https://en.wikipedia.org/wiki/Basic_access_authentication
+/** Provides an implementation of the Basic Access Authentication scheme: https://en.wikipedia.org/wiki/Basic_access_authentication . */
 public class BasicAccessAuthenticationProvider implements AuthenticationProvider {
+    private final static String AUTHORIZATION_HEADER_KEY = "Authorization";
+    private static final String BASIC = "Basic ";
 
     private final String username;
     private final String password;
     private final String encoded;
 
-    public BasicAccessAuthenticationProvider(String username, String password) {
+    /**
+     * Instantiates a new BasicAccessAuthenticationProvider.
+     * @param username the username to be used.
+     * @param password the password to be used.
+     */
+    public BasicAccessAuthenticationProvider(@Nonnull final String username, @Nonnull final String password) {
         this.username = username;
         this.password = password;
         encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
     }
 
-    private final static String AUTHORIZATION_HEADER_KEY = "Authorization";
-    public static final String BASIC = "Basic ";
     @Override
+    @Nonnull
     public CompletableFuture<Void> authenticateRequest(@Nonnull final RequestInformation request, @Nullable final Map<String, Object> additionalAuthenticationContext) {
         request.headers.add(AUTHORIZATION_HEADER_KEY, BASIC + encoded);
         return CompletableFuture.completedFuture(null);

--- a/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
@@ -29,6 +29,7 @@ public class BasicAccessAuthenticationProvider implements AuthenticationProvider
         encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
     }
 
+    /** {@inheritDoc} */
     @Override
     @Nonnull
     public CompletableFuture<Void> authenticateRequest(@Nonnull final RequestInformation request, @Nullable final Map<String, Object> additionalAuthenticationContext) {

--- a/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
@@ -7,6 +7,7 @@ import jakarta.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /** Provides an implementation of the Basic Access Authentication scheme: https://en.wikipedia.org/wiki/Basic_access_authentication . */
@@ -24,6 +25,9 @@ public class BasicAccessAuthenticationProvider implements AuthenticationProvider
      * @param password the password to be used.
      */
     public BasicAccessAuthenticationProvider(@Nonnull final String username, @Nonnull final String password) {
+        Objects.requireNonNull(username);
+        Objects.requireNonNull(password);
+
         this.username = username;
         this.password = password;
         encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));

--- a/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/authentication/BasicAccessAuthenticationProvider.java
@@ -1,0 +1,32 @@
+package com.microsoft.kiota.authentication;
+
+import com.microsoft.kiota.RequestInformation;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+// https://en.wikipedia.org/wiki/Basic_access_authentication
+public class BasicAccessAuthenticationProvider implements AuthenticationProvider {
+
+    private final String username;
+    private final String password;
+    private final String encoded;
+
+    public BasicAccessAuthenticationProvider(String username, String password) {
+        this.username = username;
+        this.password = password;
+        encoded = Base64.getEncoder().encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private final static String AUTHORIZATION_HEADER_KEY = "Authorization";
+    public static final String BASIC = "Basic ";
+    @Override
+    public CompletableFuture<Void> authenticateRequest(@Nonnull final RequestInformation request, @Nullable final Map<String, Object> additionalAuthenticationContext) {
+        request.headers.add(AUTHORIZATION_HEADER_KEY, BASIC + encoded);
+        return CompletableFuture.completedFuture(null);
+    }
+}


### PR DESCRIPTION
I have a few "clean-up" tasks from removing the hand-written Client in Apicurio Registry.
This is an easy one, but I'm looking for guidance on how to port the [Oidc one](https://github.com/Apicurio/apicurio-registry/blob/main/client/src/main/java/io/apicurio/registry/auth/OidcAccessTokenProvider.java) too.

The problem is that I need an HttpClient(or something like that / RequestAdapter etc.) to get the token(possibly during object creation), but this is used to construct the `RequestAdapter` object so we have a circular dependency.

Have you already faced this issue?
Do you have a solution that doesn't involve spinning a new, dedicated, HTTP client?