### PR TITLE
Use parent Call.Factory of OkHttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+Changed OkHttpRequestAdapter dependency from OkHttpClient to Call.Factory (parent interface implemented by OkHttpClient).
+
 ## [0.8.0] - 2023-10-31
 
 ### Added

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -48,7 +48,7 @@ import com.microsoft.kiota.store.BackingStoreFactory;
 import com.microsoft.kiota.store.BackingStoreFactorySingleton;
 
 import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
+import okhttp3.Call;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.ResponseBody;
@@ -67,7 +67,7 @@ import io.opentelemetry.context.Context;
 public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter {
     private final static String contentTypeHeaderKey = "Content-Type";
     @Nonnull
-    private final OkHttpClient client;
+    private final Call.Factory client;
     @Nonnull
     private final AuthenticationProvider authProvider;
     @Nonnull
@@ -119,7 +119,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
      * @param client the http client to use for sending requests.
      */
     @SuppressWarnings("LambdaLast")
-    public OkHttpRequestAdapter(@Nonnull final AuthenticationProvider authenticationProvider, @Nullable final ParseNodeFactory parseNodeFactory, @Nullable final SerializationWriterFactory serializationWriterFactory, @Nullable final OkHttpClient client) {
+    public OkHttpRequestAdapter(@Nonnull final AuthenticationProvider authenticationProvider, @Nullable final ParseNodeFactory parseNodeFactory, @Nullable final SerializationWriterFactory serializationWriterFactory, @Nullable final Call.Factory client) {
         this(authenticationProvider, parseNodeFactory, serializationWriterFactory, client, null);
     }
     /**
@@ -131,7 +131,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
      * @param observabilityOptions the observability options to use for sending requests.
      */
     @SuppressWarnings("LambdaLast")
-    public OkHttpRequestAdapter(@Nonnull final AuthenticationProvider authenticationProvider, @Nullable final ParseNodeFactory parseNodeFactory, @Nullable final SerializationWriterFactory serializationWriterFactory, @Nullable final OkHttpClient client, @Nullable final ObservabilityOptions observabilityOptions) {
+    public OkHttpRequestAdapter(@Nonnull final AuthenticationProvider authenticationProvider, @Nullable final ParseNodeFactory parseNodeFactory, @Nullable final SerializationWriterFactory serializationWriterFactory, @Nullable final Call.Factory client, @Nullable final ObservabilityOptions observabilityOptions) {
         this.authProvider = Objects.requireNonNull(authenticationProvider, "parameter authenticationProvider cannot be null");
         if(client == null) {
             this.client = KiotaClientFactory.create().build();


### PR DESCRIPTION
@baywet 
Same as https://github.com/microsoftgraph/msgraph-sdk-java-core/pull/1252

Call.Factory is the parent interface of OkHttpClient and allows adding your own OkHttpClient (wrapper) to be used, which can instrument the Http requests.