### PR TITLE
Add default UTC offset when deserializing to OffsetDateTime fails due to a missing time offset value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.2] - 2024-02-13
+
+### Changed
+
+- Add default UTC offset when deserializing to OffsetDateTime fails due to a missing time offset value.
+
 ## [1.0.1] - 2024-02-09
 
 ### Changed

--- a/components/serialization/form/gradle/dependencies.gradle
+++ b/components/serialization/form/gradle/dependencies.gradle
@@ -1,6 +1,7 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/components/serialization/form/src/main/java/com/microsoft/kiota/serialization/FormParseNode.java
+++ b/components/serialization/form/src/main/java/com/microsoft/kiota/serialization/FormParseNode.java
@@ -10,8 +10,11 @@ import java.math.BigDecimal;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -167,7 +170,17 @@ public class FormParseNode implements ParseNode {
     @Nullable public OffsetDateTime getOffsetDateTimeValue() {
         final String stringValue = getStringValue();
         if (stringValue == null) return null;
-        return OffsetDateTime.parse(stringValue);
+        try {
+            return OffsetDateTime.parse(stringValue);
+        } catch (DateTimeParseException ex) {
+            // Append UTC offset if it's missing
+            try {
+                LocalDateTime localDateTime = LocalDateTime.parse(stringValue);
+                return localDateTime.atOffset(ZoneOffset.UTC);
+            } catch (DateTimeParseException ex2) {
+                throw ex;
+            }
+        }
     }
 
     @Nullable public LocalDate getLocalDateValue() {

--- a/components/serialization/json/gradle/dependencies.gradle
+++ b/components/serialization/json/gradle/dependencies.gradle
@@ -1,6 +1,7 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
+++ b/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
@@ -11,8 +11,11 @@ import jakarta.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.EnumSet;
@@ -95,7 +98,17 @@ public class JsonParseNode implements ParseNode {
     @Nullable public OffsetDateTime getOffsetDateTimeValue() {
         final String stringValue = currentNode.getAsString();
         if (stringValue == null) return null;
-        return OffsetDateTime.parse(stringValue);
+        try {
+            return OffsetDateTime.parse(stringValue);
+        } catch (DateTimeParseException ex) {
+            // Append UTC offset if it's missing
+            try {
+                LocalDateTime localDateTime = LocalDateTime.parse(stringValue);
+                return localDateTime.atOffset(ZoneOffset.UTC);
+            } catch (DateTimeParseException ex2) {
+                throw ex;
+            }
+        }
     }
 
     @Nullable public LocalDate getLocalDateValue() {

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
@@ -49,7 +49,7 @@ class JsonParseNodeTests {
     void testInvalidOffsetDateTimeStringThrowsException(final String dateTimeString) {
         final var jsonElement = JsonParser.parseString("\"" + dateTimeString + "\"");
         try {
-            final var result = new JsonParseNode(jsonElement).getOffsetDateTimeValue();
+            new JsonParseNode(jsonElement).getOffsetDateTimeValue();
         } catch (final Exception ex) {
             assertInstanceOf(DateTimeParseException.class, ex);
             assertTrue(ex.getMessage().contains(dateTimeString));

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
@@ -1,11 +1,19 @@
 package com.microsoft.kiota.serialization;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.JsonParser;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
+import java.time.format.DateTimeParseException;
 
 class JsonParseNodeTests {
     private static final JsonParseNodeFactory _parseNodeFactory = new JsonParseNodeFactory();
@@ -18,5 +26,33 @@ class JsonParseNodeTests {
         final var parseNode = _parseNodeFactory.getParseNode(contentType, rawResponse);
         final var result = parseNode.getChildNode("@odata.type");
         assertNull(result);
+    }
+
+    @Test
+    void testParsesDateTimeOffset() {
+        final var dateTimeOffsetString = "2024-02-12T19:47:39+02:00";
+        final var jsonElement = JsonParser.parseString("\"" + dateTimeOffsetString + "\"");
+        final var result = new JsonParseNode(jsonElement).getOffsetDateTimeValue();
+        assertEquals(dateTimeOffsetString, result.toString());
+    }
+
+    @Test
+    void testParsesDateTimeStringWithoutOffsetToDateTimeOffset() {
+        final var dateTimeString = "2024-02-12T19:47:39";
+        final var jsonElement = JsonParser.parseString("\"" + dateTimeString + "\"");
+        final var result = new JsonParseNode(jsonElement).getOffsetDateTimeValue();
+        assertEquals(dateTimeString + "Z", result.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2024-02-12T19:47:39 Europe/Paris", "19:47:39"})
+    void testInvalidOffsetDateTimeStringThrowsException(final String dateTimeString) {
+        final var jsonElement = JsonParser.parseString("\"" + dateTimeString + "\"");
+        try {
+            final var result = new JsonParseNode(jsonElement).getOffsetDateTimeValue();
+        } catch (final Exception ex) {
+            assertInstanceOf(DateTimeParseException.class, ex);
+            assertTrue(ex.getMessage().contains(dateTimeString));
+        }
     }
 }

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/UnionWrapperParseTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/UnionWrapperParseTests.java
@@ -21,7 +21,7 @@ class UnionWrapperParseTests {
     private static final String contentType = "application/json";
 
     @Test
-    void ParsesUnionTypeComplexProperty1() throws UnsupportedEncodingException {
+    void parsesUnionTypeComplexProperty1() throws UnsupportedEncodingException {
         final var initialString =
                 "{\"@odata.type\":\"#microsoft.graph.testEntity\",\"officeLocation\":\"Montreal\","
                         + " \"id\": \"opaque\"}";
@@ -38,7 +38,7 @@ class UnionWrapperParseTests {
     }
 
     @Test
-    void ParsesUnionTypeComplexProperty2() throws UnsupportedEncodingException {
+    void parsesUnionTypeComplexProperty2() throws UnsupportedEncodingException {
         final var initialString =
                 "{\"@odata.type\":\"#microsoft.graph.secondTestEntity\",\"officeLocation\":\"Montreal\","
                     + " \"id\": 10}";
@@ -54,7 +54,7 @@ class UnionWrapperParseTests {
     }
 
     @Test
-    void ParsesUnionTypeComplexProperty3() throws UnsupportedEncodingException {
+    void parsesUnionTypeComplexProperty3() throws UnsupportedEncodingException {
         final var initialString =
                 "[{\"@odata.type\":\"#microsoft.graph.TestEntity\",\"officeLocation\":\"Ottawa\","
                     + " \"id\": \"11\"},"
@@ -73,7 +73,7 @@ class UnionWrapperParseTests {
     }
 
     @Test
-    void ParsesUnionTypeStringValue() throws UnsupportedEncodingException {
+    void parsesUnionTypeStringValue() throws UnsupportedEncodingException {
         final var initialString = "\"officeLocation\"";
         final var rawResponse = new ByteArrayInputStream(initialString.getBytes("UTF-8"));
         final var parseNode = _parseNodeFactory.getParseNode(contentType, rawResponse);
@@ -87,7 +87,7 @@ class UnionWrapperParseTests {
     }
 
     @Test
-    void SerializesUnionTypeStringValue() throws IOException {
+    void serializesUnionTypeStringValue() throws IOException {
         try (final var writer = _serializationWriterFactory.getSerializationWriter(contentType)) {
             var model =
                     new UnionTypeMock() {
@@ -105,7 +105,7 @@ class UnionWrapperParseTests {
     }
 
     @Test
-    void SerializesUnionTypeComplexProperty1() throws IOException {
+    void serializesUnionTypeComplexProperty1() throws IOException {
         try (final var writer = _serializationWriterFactory.getSerializationWriter(contentType)) {
             var model =
                     new UnionTypeMock() {
@@ -135,7 +135,7 @@ class UnionWrapperParseTests {
     }
 
     @Test
-    void SerializesUnionTypeComplexProperty2() throws IOException {
+    void serializesUnionTypeComplexProperty2() throws IOException {
         try (final var writer = _serializationWriterFactory.getSerializationWriter(contentType)) {
             var model =
                     new UnionTypeMock() {
@@ -159,7 +159,7 @@ class UnionWrapperParseTests {
     }
 
     @Test
-    void SerializesUnionTypeComplexProperty3() throws IOException {
+    void serializesUnionTypeComplexProperty3() throws IOException {
         try (final var writer = _serializationWriterFactory.getSerializationWriter(contentType)) {
             var model =
                     new UnionTypeMock() {

--- a/components/serialization/text/gradle/dependencies.gradle
+++ b/components/serialization/text/gradle/dependencies.gradle
@@ -1,12 +1,13 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
-    
+
     api project(':components:abstractions')
 }

--- a/components/serialization/text/src/main/java/com/microsoft/kiota/serialization/TextParseNode.java
+++ b/components/serialization/text/src/main/java/com/microsoft/kiota/serialization/TextParseNode.java
@@ -7,8 +7,11 @@ import jakarta.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.Base64;
 import java.util.EnumSet;
 import java.util.List;
@@ -79,7 +82,17 @@ public class TextParseNode implements ParseNode {
     }
 
     @Nullable public OffsetDateTime getOffsetDateTimeValue() {
-        return OffsetDateTime.parse(this.getStringValue());
+        try {
+            return OffsetDateTime.parse(this.getStringValue());
+        } catch (DateTimeParseException ex) {
+            // Append UTC offset if it's missing
+            try {
+                LocalDateTime localDateTime = LocalDateTime.parse(this.getStringValue());
+                return localDateTime.atOffset(ZoneOffset.UTC);
+            } catch (DateTimeParseException ex2) {
+                throw ex;
+            }
+        }
     }
 
     @Nullable public LocalDate getLocalDateValue() {

--- a/components/serialization/text/src/test/java/com/microsoft/kiota/serialization/TextParseNodeTest.java
+++ b/components/serialization/text/src/test/java/com/microsoft/kiota/serialization/TextParseNodeTest.java
@@ -1,0 +1,39 @@
+package com.microsoft.kiota.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.format.DateTimeParseException;
+
+public class TextParseNodeTest {
+
+    @Test
+    void testParsesDateTimeOffset() {
+        final var dateTimeOffsetString = "2024-02-12T19:47:39+02:00";
+        final var result = new TextParseNode(dateTimeOffsetString).getOffsetDateTimeValue();
+        assertEquals(dateTimeOffsetString, result.toString());
+    }
+
+    @Test
+    void testParsesDateTimeStringWithoutOffsetToDateTimeOffset() {
+        final var dateTimeString = "2024-02-12T19:47:39";
+        final var result = new TextParseNode(dateTimeString).getOffsetDateTimeValue();
+        assertEquals(dateTimeString + "Z", result.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2024-02-12T19:47:39 Europe/Paris", "19:47:39"})
+    void testInvalidOffsetDateTimeStringThrowsException(final String dateTimeString) {
+        try {
+            new TextParseNode(dateTimeString).getOffsetDateTimeValue();
+        } catch (final Exception ex) {
+            assertInstanceOf(DateTimeParseException.class, ex);
+            assertTrue(ex.getMessage().contains(dateTimeString));
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
 mavenMinorVersion = 0
-mavenPatchVersion = 1
+mavenPatchVersion = 2
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests


### PR DESCRIPTION
Checks for failure case by parsing to [LocalDateTime](https://docs.oracle.com/javase/8/docs/api/java/time/LocalDateTime.html) (doesn't contain time offset), otherwise returns initial OffsetDateTime parsing exception.

closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1785