### PR TITLE
[ Java 8 ]: Replace isBlank with Compatibility.isBlank()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.3] - 2024-02-21
+
+### Changed
+
+- Fixed compatibility with Java 8 by replacing `isBlank` with `Compatibility.isBlank`
+
 ## [1.0.2] - 2024-02-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Read more about Kiota [here](https://github.com/microsoft/kiota/blob/main/README
 In `build.gradle` in the `dependencies` section:
 
 ```Groovy
-implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:1.0.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.0.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.0.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.0.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.0.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.0.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.0.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:1.0.3'
+implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.0.3'
+implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.0.3'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.0.3'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.0.3'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.0.3'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.0.3'
 ```
 
 ### With Maven:
@@ -38,37 +38,37 @@ In `pom.xml` in the `dependencies` section:
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-abstractions</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-authentication-azure</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-http-okHttp</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-json</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-text</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-form</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-multipart</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.3</version>
     </dependency>
 ```
 

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/ParametersNameDecodingHandler.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/ParametersNameDecodingHandler.java
@@ -1,5 +1,6 @@
 package com.microsoft.kiota.http.middleware;
 
+import com.microsoft.kiota.Compatibility;
 import com.microsoft.kiota.http.middleware.options.ParametersNameDecodingOption;
 
 import io.opentelemetry.api.trace.Span;
@@ -107,7 +108,7 @@ public class ParametersNameDecodingHandler implements Interceptor {
             @Nullable final String original, @Nonnull final char[] charactersToDecode) {
         Objects.requireNonNull(charactersToDecode);
 
-        if (original == null || original.isBlank() || charactersToDecode.length == 0) {
+        if (original == null || Compatibility.isBlank(original) || charactersToDecode.length == 0) {
             return "";
         }
 
@@ -152,7 +153,7 @@ public class ParametersNameDecodingHandler implements Interceptor {
         return toDecode.stream()
                 .map(
                         tuple ->
-                                tuple.getKey().isBlank()
+                                Compatibility.isBlank(tuple.getKey())
                                         ? tuple.getValue()
                                         : tuple.getValue() + "=" + tuple.getKey())
                 .collect(Collectors.joining("&"));

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
 mavenMinorVersion = 0
-mavenPatchVersion = 2
+mavenPatchVersion = 3
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests


### PR DESCRIPTION
Recently ran into an issue at my work with compatibility to Java 8 being broken in `msgraph-sdk-java` due to this kiota-java dependency. 

closes microsoftgraph/msgraph-sdk-java#1831