### PR TITLE
adds skip packaging option

### DIFF
--- a/components/authentication/azure/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProvider.java
+++ b/components/authentication/azure/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProvider.java
@@ -66,9 +66,9 @@ public class AzureIdentityAccessTokenProvider implements AccessTokenProvider {
             _scopes = Arrays.asList(scopes);
         }
         if (allowedHosts == null || allowedHosts.length == 0) {
-            _hostValidator = new AllowedHostsValidator();
+            this._hostValidator = new AllowedHostsValidator();
         } else {
-            _hostValidator = new AllowedHostsValidator(allowedHosts);
+            this._hostValidator = new AllowedHostsValidator(allowedHosts);
         }
         if (observabilityOptions == null) {
             _observabilityOptions = new ObservabilityOptions();
@@ -147,7 +147,8 @@ public class AzureIdentityAccessTokenProvider implements AccessTokenProvider {
         }
     }
 
-    @Nonnull public AllowedHostsValidator getAllowedHostsValidator() {
+    @Nonnull 
+    public AllowedHostsValidator getAllowedHostsValidator() {
         return _hostValidator;
     }
 

--- a/components/authentication/azure/src/main/java/com/microsoft/kiota/authentication/tempCodeRunnerFile.java
+++ b/components/authentication/azure/src/main/java/com/microsoft/kiota/authentication/tempCodeRunnerFile.java
@@ -1,0 +1,4 @@
+package com.microsoft.kiota.authentication;
+@Nonnull public AllowedHostsValidator getAllowedHostsValidator() {
+    return _hostValidator;
+}


### PR DESCRIPTION
 Ensured that _hostValidator is properly declared and initialized within the AzureIdentityAccessTokenProvider class.
Added dependencies in the build.gradle file.