### PR TITLE
Fix UnsupportedOperationException when not providing scopes to AzureIdentityAccessTokenProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fixed a bug where not providing scopes to `AzureIdentityAccessTokenProvider` failed with `UnsupportedOperationException` when attempting to fetch the token. [microsoftgraph/msgraph-sdk-java#1882](https://github.com/microsoftgraph/msgraph-sdk-java/issues/1882)  
+
 ## [1.0.6] - 2023-03-04
 
 ### Changed 

--- a/components/authentication/azure/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProvider.java
+++ b/components/authentication/azure/src/main/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProvider.java
@@ -63,7 +63,7 @@ public class AzureIdentityAccessTokenProvider implements AccessTokenProvider {
         if (scopes == null) {
             _scopes = new ArrayList<String>();
         } else {
-            _scopes = Arrays.asList(scopes);
+            _scopes = new ArrayList<>(Arrays.asList(scopes));
         }
         if (allowedHosts == null || allowedHosts.length == 0) {
             _hostValidator = new AllowedHostsValidator();

--- a/components/authentication/azure/src/test/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProviderTest.java
+++ b/components/authentication/azure/src/test/java/com/microsoft/kiota/authentication/AzureIdentityAccessTokenProviderTest.java
@@ -1,19 +1,27 @@
 package com.microsoft.kiota.authentication;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 public class AzureIdentityAccessTokenProviderTest {
 
@@ -40,5 +48,58 @@ public class AzureIdentityAccessTokenProviderTest {
                 () ->
                         accessTokenProvider.getAuthorizationToken(
                                 new URI(urlString), new HashMap<>()));
+    }
+
+    @Test
+    void testKeepUserProvidedScopes() throws URISyntaxException {
+        var tokenCredential = mock(TokenCredential.class);
+        String[] userProvidedScopes = {
+            "https://graph.microsoft.com/User.Read", "https://graph.microsoft.com/Application.Read"
+        };
+        var accessTokenProvider =
+                new AzureIdentityAccessTokenProvider(
+                        tokenCredential, new String[] {}, userProvidedScopes);
+        assertScopes(tokenCredential, accessTokenProvider, userProvidedScopes);
+    }
+
+    @Test
+    void testConfigureDefaultScopeWhenScopesNotProvided() throws URISyntaxException {
+        var tokenCredential = mock(TokenCredential.class);
+        var accessTokenProvider =
+                new AzureIdentityAccessTokenProvider(tokenCredential, new String[] {});
+        assertScopes(
+                tokenCredential,
+                accessTokenProvider,
+                new String[] {"https://graph.microsoft.com/.default"});
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void testConfigureDefaultScopeWhenScopesNullOrEmpty(String[] nullOrEmptyUserProvidedScopes)
+            throws URISyntaxException {
+        var tokenCredential = mock(TokenCredential.class);
+        var accessTokenProvider =
+                new AzureIdentityAccessTokenProvider(
+                        tokenCredential, new String[] {}, nullOrEmptyUserProvidedScopes);
+        assertScopes(
+                tokenCredential,
+                accessTokenProvider,
+                new String[] {"https://graph.microsoft.com/.default"});
+    }
+
+    private static void assertScopes(
+            TokenCredential tokenCredential,
+            AzureIdentityAccessTokenProvider accessTokenProvider,
+            String[] expectedScopes)
+            throws URISyntaxException {
+        var tokenRequestContextArgumentCaptor = ArgumentCaptor.forClass(TokenRequestContext.class);
+        when(tokenCredential.getTokenSync(tokenRequestContextArgumentCaptor.capture()))
+                .thenReturn(mock(AccessToken.class));
+
+        accessTokenProvider.getAuthorizationToken(
+                new URI("https://graph.microsoft.com"), new HashMap<>());
+
+        List<String> actualScopes = tokenRequestContextArgumentCaptor.getValue().getScopes();
+        assertLinesMatch(actualScopes, Arrays.asList(expectedScopes));
     }
 }


### PR DESCRIPTION
Fixes microsoftgraph/msgraph-sdk-java#1882