### PR TITLE
Fixes IllegalStateException when jsonarray is in additionalData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.1.3] - 2024-04-02
+
+### Changed
+
+- Fixes a bug in the seriliazer that would `IllegalStateException` for json arrays in the additional data.
+
 ## [1.1.2] - 2024-03-26
 
 ### Changed

--- a/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
+++ b/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
@@ -163,8 +163,8 @@ public class JsonParseNode implements ParseNode {
         }
     }
 
-    private <T> List<T> iterateOnArray(Function<JsonParseNode, T> fn) {
-        JsonArray array = currentNode.getAsJsonArray();
+    private <T> List<T> iterateOnArray(JsonElement jsonElement, Function<JsonParseNode, T> fn) {
+        JsonArray array = jsonElement.getAsJsonArray();
         final Iterator<JsonElement> sourceIterator = array.iterator();
         final List<T> result = new ArrayList<>();
         while (sourceIterator.hasNext()) {
@@ -182,7 +182,8 @@ public class JsonParseNode implements ParseNode {
         if (currentNode.isJsonNull()) {
             return null;
         } else if (currentNode.isJsonArray()) {
-            return iterateOnArray(itemNode -> getPrimitiveValue(targetClass, itemNode));
+            return iterateOnArray(
+                    currentNode, itemNode -> getPrimitiveValue(targetClass, itemNode));
         } else throw new RuntimeException("invalid state expected to have an array node");
     }
 
@@ -192,7 +193,7 @@ public class JsonParseNode implements ParseNode {
         if (currentNode.isJsonNull()) {
             return null;
         } else if (currentNode.isJsonArray()) {
-            return iterateOnArray(itemNode -> itemNode.getObjectValue(factory));
+            return iterateOnArray(currentNode, itemNode -> itemNode.getObjectValue(factory));
         } else return null;
     }
 
@@ -202,7 +203,7 @@ public class JsonParseNode implements ParseNode {
         if (currentNode.isJsonNull()) {
             return null;
         } else if (currentNode.isJsonArray()) {
-            return iterateOnArray(itemNode -> itemNode.getEnumValue(enumParser));
+            return iterateOnArray(currentNode, itemNode -> itemNode.getEnumValue(enumParser));
         } else throw new RuntimeException("invalid state expected to have an array node");
     }
 
@@ -242,7 +243,7 @@ public class JsonParseNode implements ParseNode {
             return new UntypedObject(propertiesMap);
 
         } else if (element.isJsonArray()) {
-            return new UntypedArray(iterateOnArray(JsonParseNode::getUntypedValue));
+            return new UntypedArray(iterateOnArray(element, JsonParseNode::getUntypedValue));
         }
 
         throw new RuntimeException(

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
@@ -3,6 +3,7 @@ package com.microsoft.kiota.serialization;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.gson.JsonParser;
+import com.microsoft.kiota.serialization.mocks.TestEntity;
 import com.microsoft.kiota.serialization.mocks.UntypedTestEntity;
 
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,10 @@ import java.time.format.DateTimeParseException;
 class JsonParseNodeTests {
     private static final JsonParseNodeFactory _parseNodeFactory = new JsonParseNodeFactory();
     private static final String contentType = "application/json";
+
+    private static final String testJsonString =
+            "{\"displayName\":\"My Group\",\"id\":\"11111111-1111-1111-1111-111111111111"
+                + "\",\"members@delta\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"22222222-2222-2222-2222-222222222222\"}]}";
     private static final String testUntypedJson =
             "{\r\n"
                 + "    \"@odata.context\":"
@@ -93,6 +98,17 @@ class JsonParseNodeTests {
             assertInstanceOf(DateTimeParseException.class, ex);
             assertTrue(ex.getMessage().contains(dateTimeString));
         }
+    }
+
+    @Test
+    void getEntityWithArrayInAdditionalData() throws UnsupportedEncodingException {
+        final var rawResponse = new ByteArrayInputStream(testJsonString.getBytes("UTF-8"));
+        final var parseNode = _parseNodeFactory.getParseNode(contentType, rawResponse);
+        // Act
+        var entity = parseNode.getObjectValue(TestEntity::createFromDiscriminatorValue);
+        assertEquals("11111111-1111-1111-1111-111111111111", entity.getId());
+        final var arrayValue = (UntypedArray) entity.getAdditionalData().get("members@delta");
+        assertEquals(1, arrayValue.getValue().spliterator().estimateSize());
     }
 
     @Test

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
@@ -3,6 +3,7 @@ package com.microsoft.kiota.serialization;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.gson.JsonParser;
+import com.microsoft.kiota.serialization.mocks.MyEnum;
 import com.microsoft.kiota.serialization.mocks.TestEntity;
 import com.microsoft.kiota.serialization.mocks.UntypedTestEntity;
 
@@ -19,7 +20,8 @@ class JsonParseNodeTests {
     private static final String contentType = "application/json";
 
     private static final String testJsonString =
-            "{\"displayName\":\"My Group\",\"id\":\"11111111-1111-1111-1111-111111111111"
+            "{\"displayName\":\"My"
+                + " Group\",\"phones\":[\"+1234567890\"],\"myEnum\":\"VALUE1\",\"enumCollection\":[\"VALUE1\"],\"id\":\"11111111-1111-1111-1111-111111111111"
                 + "\",\"members@delta\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"22222222-2222-2222-2222-222222222222\"}]}";
     private static final String testUntypedJson =
             "{\r\n"
@@ -107,6 +109,9 @@ class JsonParseNodeTests {
         // Act
         var entity = parseNode.getObjectValue(TestEntity::createFromDiscriminatorValue);
         assertEquals("11111111-1111-1111-1111-111111111111", entity.getId());
+        assertEquals(1, entity.getPhones().size());
+        assertEquals(MyEnum.MY_VALUE1, entity.getMyEnum());
+        assertEquals(1, entity.getEnumCollection().size());
         final var arrayValue = (UntypedArray) entity.getAdditionalData().get("members@delta");
         assertEquals(1, arrayValue.getValue().spliterator().estimateSize());
     }

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/mocks/TestEntity.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/mocks/TestEntity.java
@@ -9,7 +9,9 @@ import com.microsoft.kiota.serialization.SerializationWriter;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -23,6 +25,16 @@ public class TestEntity implements Parsable, AdditionalDataHolder {
 
     public void setId(String _id) {
         this._id = _id;
+    }
+
+    private List<String> _phones;
+
+    public List<String> getPhones() {
+        return _phones;
+    }
+
+    public void setPhones(List<String> _phones) {
+        this._phones = new ArrayList<String>(_phones);
     }
 
     private String _officeLocation;
@@ -85,6 +97,16 @@ public class TestEntity implements Parsable, AdditionalDataHolder {
         this._myEnum = value;
     }
 
+    private List<MyEnum> _enumCollection;
+
+    public List<MyEnum> getEnumCollection() {
+        return _enumCollection;
+    }
+
+    public void setEnumCollection(List<MyEnum> value) {
+        this._enumCollection = new ArrayList<MyEnum>(value);
+    }
+
     private OffsetDateTime _createdDateTime;
 
     public OffsetDateTime getCreatedDateTime() {
@@ -135,9 +157,19 @@ public class TestEntity implements Parsable, AdditionalDataHolder {
                             setMyEnum(n.getEnumValue(MyEnum::forValue));
                         });
                 put(
+                        "enumCollection",
+                        (n) -> {
+                            setEnumCollection(n.getCollectionOfEnumValues(MyEnum::forValue));
+                        });
+                put(
                         "createdDateTime",
                         (n) -> {
                             setCreatedDateTime(n.getOffsetDateTimeValue());
+                        });
+                put(
+                        "phones",
+                        (n) -> {
+                            setPhones(n.getCollectionOfPrimitiveValues(String.class));
                         });
             }
         };
@@ -153,7 +185,9 @@ public class TestEntity implements Parsable, AdditionalDataHolder {
         writer.writeLocalTimeValue("startWorkTime", getStartWorkTime());
         writer.writeLocalTimeValue("endWorkTime", getEndWorkTime());
         writer.writeEnumValue("myEnum", getMyEnum());
+        writer.writeCollectionOfEnumValues("enumCollection", getEnumCollection());
         writer.writeOffsetDateTimeValue("createdDateTime", getCreatedDateTime());
+        writer.writeCollectionOfPrimitiveValues("phones", getPhones());
         writer.writeAdditionalData(getAdditionalData());
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
 mavenMinorVersion = 1
-mavenPatchVersion = 2
+mavenPatchVersion = 3
 mavenArtifactSuffix = 
 
 #These values are used to run functional tests


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota-java/issues/1147

`iterateOnArray` tries to parse the root json element instead of the child element that is the array when handling an item from the additionalData. 