### PR TITLE
Changed the initialization method of the options field in BaseRequestConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.8] - 2024-04-25
+
+### Changed
+
+- Fixed a bug where options could not be added to request information. [#1238](https://github.com/microsoft/kiota-java/issues/1238)
+
 ## [1.1.7] - 2024-04-23
 
 ### Changed

--- a/components/abstractions/src/main/java/com/microsoft/kiota/BaseRequestConfiguration.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/BaseRequestConfiguration.java
@@ -2,7 +2,7 @@ package com.microsoft.kiota;
 
 import jakarta.annotation.Nonnull;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -24,5 +24,5 @@ public abstract class BaseRequestConfiguration {
     /**
      * Request options
      */
-    @Nonnull public List<RequestOption> options = Collections.emptyList();
+    @Nonnull public List<RequestOption> options = new ArrayList<RequestOption>();
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/BaseRequestConfigurationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/BaseRequestConfigurationTest.java
@@ -1,0 +1,32 @@
+package com.microsoft.kiota;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class BaseRequestConfigurationTest {
+
+    public static class TestRequestConfiguration extends BaseRequestConfiguration {
+        public TestRequestConfiguration() {
+            super();
+        }
+    }
+
+    @Test
+    void testOptions() {
+        TestRequestConfiguration requestConfiguration = new TestRequestConfiguration();
+        assertNotNull(requestConfiguration.options);
+
+        RequestOption requestOption = new RequestOption() {
+            @Override
+            public <T extends RequestOption> Class<T> getType() {
+                return null;
+            }
+        };
+        // options should be mutable list
+        requestConfiguration.options.add(requestOption);
+        assertEquals(1, requestConfiguration.options.size());
+        assertEquals(requestOption, requestConfiguration.options.get(0));
+    }
+}

--- a/components/abstractions/src/test/java/com/microsoft/kiota/BaseRequestConfigurationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/BaseRequestConfigurationTest.java
@@ -18,12 +18,13 @@ public class BaseRequestConfigurationTest {
         TestRequestConfiguration requestConfiguration = new TestRequestConfiguration();
         assertNotNull(requestConfiguration.options);
 
-        RequestOption requestOption = new RequestOption() {
-            @Override
-            public <T extends RequestOption> Class<T> getType() {
-                return null;
-            }
-        };
+        RequestOption requestOption =
+                new RequestOption() {
+                    @Override
+                    public <T extends RequestOption> Class<T> getType() {
+                        return null;
+                    }
+                };
         // options should be mutable list
         requestConfiguration.options.add(requestOption);
         assertEquals(1, requestConfiguration.options.size());

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/options/UserAgentHandlerOption.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/options/UserAgentHandlerOption.java
@@ -13,7 +13,7 @@ public class UserAgentHandlerOption implements RequestOption {
 
     private boolean enabled = true;
     @Nonnull private String productName = "kiota-java";
-    @Nonnull private String productVersion = "1.1.1";
+    @Nonnull private String productVersion = "1.1.8";
 
     /**
      * Gets the product name to be used in the user agent header

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
 mavenMinorVersion = 1
-mavenPatchVersion = 7
+mavenPatchVersion = 8
 mavenArtifactSuffix =
 
 #These values are used to run functional tests


### PR DESCRIPTION
This PR changes the initialization method of the options field in BaseRequestConfiguration from an immutable list to a mutable one.

## related issue

- fixes https://github.com/microsoft/kiota-java/issues/1238
- fixes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1933