### PR TITLE
Issue 1241: opentelemtry attribute typing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.10] - 2024-05-06
+
+### Changed
+
+- Fixing a bug where the type associated the opentelemetry metric attribute `server.port` was defined as a string instead of a long. [#1241](https://github.com/microsoft/kiota-java/issues/1241)
+
 ## [1.1.9] - 2024-04-26
 
 ### Changed

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/TelemetrySemanticConventions.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/TelemetrySemanticConventions.java
@@ -19,7 +19,7 @@ public class TelemetrySemanticConventions {
     public static final AttributeKey URL_FULL = stringKey("url.full"); // stable
     public static final AttributeKey URL_SCHEME = stringKey("url.scheme"); // stable
     public static final AttributeKey SERVER_ADDRESS = stringKey("server.address"); // stable
-    public static final AttributeKey SERVER_PORT = stringKey("server.port"); // stable
+    public static final AttributeKey SERVER_PORT = longKey("server.port"); // stable
 
     public static final AttributeKey EXPERIMENTAL_HTTP_RESPONSE_BODY_SIZE =
             longKey("http.response.body.size"); // experimental

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
 mavenMinorVersion = 1
-mavenPatchVersion = 9
+mavenPatchVersion = 10
 mavenArtifactSuffix =
 
 #These values are used to run functional tests


### PR DESCRIPTION
fixes #1241

Updating the opentelementry attribute definition for `SERVER_PORT` from a `stringKey` to the type appropriate `longKey`.