### PR TITLE
Revert "Bump jakarta.annotation:jakarta.annotation-api from 2.1.1 to 3.0.0 in /components/authentication/azure/android"

### DIFF
--- a/components/authentication/azure/gradle/dependencies.gradle
+++ b/components/authentication/azure/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'io.opentelemetry:opentelemetry-api:1.37.0'
     implementation 'io.opentelemetry:opentelemetry-context:1.37.0'
-    implementation 'jakarta.annotation:jakarta.annotation-api:3.0.0'
+    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
     api 'com.azure:azure-core:1.49.0'
 
     api project(':components:abstractions')


### PR DESCRIPTION
Reverts microsoft/kiota-java#1270

Related to https://github.com/microsoft/kiota-java/pull/1269 and https://github.com/microsoft/kiota-java/pull/1259