### PR TITLE
Fixes serialization of parsables in additionalData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.13] - 2024-05-31
+
+### Changed
+
+- Fixed a bug where Parsable instances in the `additionalData` would lead to failed serialization with an `IllegalStateException`. [microsoftgraph/msgraph-sdk-java#1969](https://github.com/microsoftgraph/msgraph-sdk-java/issues/1969)
+
 ## [1.1.12] - 2024-05-21
 
 ### Changed

--- a/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
+++ b/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
@@ -489,6 +489,7 @@ public class JsonSerializationWriter implements SerializationWriter {
                 this.writePeriodAndDurationValue(key, (PeriodAndDuration) value);
             else if (value instanceof Iterable<?>)
                 this.writeCollectionOfPrimitiveValues(key, (Iterable<?>) value);
+            else if (value instanceof Parsable) this.writeObjectValue(key, (Parsable) value);
             else if (!valueClass.isPrimitive()) this.writeNonParsableObject(key, value);
             else throw new RuntimeException("unknown type to serialize " + valueClass.getName());
         }

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
@@ -3,15 +3,43 @@ package com.microsoft.kiota.serialization;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.microsoft.kiota.Compatibility;
+import com.microsoft.kiota.serialization.mocks.MyEnum;
+import com.microsoft.kiota.serialization.mocks.TestEntity;
 import com.microsoft.kiota.serialization.mocks.UntypedTestEntity;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
 class JsonSerializationWriterTests {
+
+    @Test
+    void writesSampleObjectValueWithParsableInAddtionalData() throws IOException {
+        var testEntity = new TestEntity();
+        testEntity.setId("test_id");
+        var phones = new ArrayList<String>();
+        phones.add("123456789");
+        testEntity.setPhones(phones);
+        var managerAdditionalData = new TestEntity();
+        managerAdditionalData.setId("manager_id");
+        managerAdditionalData.setMyEnum(MyEnum.MY_VALUE1);
+
+        testEntity
+                .getAdditionalData()
+                .put("manager", managerAdditionalData); // place a parsable in the addtionaldata
+
+        var jsonSerializer = new JsonSerializationWriter();
+        jsonSerializer.writeObjectValue("", testEntity);
+        var contentStream = jsonSerializer.getSerializedContent();
+        var serializedJsonString = new String(Compatibility.readAllBytes(contentStream), "UTF-8");
+        // Assert
+        var expectedString =
+                "{\"id\":\"test_id\",\"phones\":[\"123456789\"],\"manager\":{\"id\":\"manager_id\",\"myEnum\":\"VALUE1\"}}";
+        assertEquals(expectedString, serializedJsonString);
+    }
 
     @Test
     void writesSampleObjectValueWithUntypedProperties() throws IOException {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
 mavenMinorVersion = 1
-mavenPatchVersion = 12
+mavenPatchVersion = 13
 mavenArtifactSuffix =
 
 #These values are used to run functional tests


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-sdk-java/issues/1969

Presence of a `Parsable` instance in the additionalData wasn't handled appropiately. So the property name was written without the value leading to invalid/illegal state.