### PR TITLE
Fixes serialization of double instances in additionalData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.14] - 2024-06-10
+
+### Changed
+
+- Fixed a bug where `Double` instances in the `additionalData` would lead to failed serialization with an `IllegalStateException`.
+
 ## [1.1.13] - 2024-05-31
 
 ### Changed

--- a/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
+++ b/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java
@@ -475,6 +475,7 @@ public class JsonSerializationWriter implements SerializationWriter {
             else if (valueClass.equals(BigDecimal.class))
                 this.writeBigDecimalValue(key, (BigDecimal) value);
             else if (valueClass.equals(Float.class)) this.writeFloatValue(key, (Float) value);
+            else if (valueClass.equals(Double.class)) this.writeDoubleValue(key, (Double) value);
             else if (valueClass.equals(Long.class)) this.writeLongValue(key, (Long) value);
             else if (valueClass.equals(Integer.class)) this.writeIntegerValue(key, (Integer) value);
             else if (valueClass.equals(UUID.class)) this.writeUUIDValue(key, (UUID) value);

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
@@ -13,11 +13,59 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 class JsonSerializationWriterTests {
 
     @Test
-    void writesSampleObjectValueWithParsableInAddtionalData() throws IOException {
+    void writesSampleObjectValueWithPrimitivesInAdditionalData() throws IOException {
+        var testEntity = new TestEntity();
+
+        Double accountBalance = 330.7;
+        testEntity
+                .getAdditionalData()
+                .put("accountBalance", accountBalance); // place a double in the additional data
+
+        testEntity
+                .getAdditionalData()
+                .put("nickName", "Peter Pan"); // place a string in the additional data
+
+        int reportsCount = 4;
+        testEntity
+                .getAdditionalData()
+                .put("reportsCount", reportsCount); // place a int in the additional data
+
+        float averageScore = 78.142F;
+        testEntity
+                .getAdditionalData()
+                .put("averageScore", averageScore); // place a float in the additional data
+
+        boolean hasDependents = true;
+        testEntity
+                .getAdditionalData()
+                .put("hasDependents", hasDependents); // place a bool in the additional data
+
+        List<String> aliases = new ArrayList<>();
+        aliases.add("alias1");
+        aliases.add("alias2");
+
+        testEntity
+                .getAdditionalData()
+                .put("aliases", aliases); // place a collection in the additional data
+
+        var jsonSerializer = new JsonSerializationWriter();
+        jsonSerializer.writeObjectValue("", testEntity);
+        var contentStream = jsonSerializer.getSerializedContent();
+        var serializedJsonString = new String(Compatibility.readAllBytes(contentStream), "UTF-8");
+        // Assert
+        var expectedString =
+                "{\"aliases\":[\"alias1\",\"alias2\"],\"nickName\":\"Peter"
+                    + " Pan\",\"hasDependents\":true,\"accountBalance\":330.7,\"reportsCount\":4,\"averageScore\":78.142}";
+        assertEquals(expectedString, serializedJsonString);
+    }
+
+    @Test
+    void writesSampleObjectValueWithParsableInAdditionalData() throws IOException {
         var testEntity = new TestEntity();
         testEntity.setId("test_id");
         var phones = new ArrayList<String>();

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ org.gradle.caching=true
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
 mavenMinorVersion = 1
-mavenPatchVersion = 13
+mavenPatchVersion = 14
 mavenArtifactSuffix =
 
 #These values are used to run functional tests


### PR DESCRIPTION
Fixes serialization of double instances in additionalData leading to `IllegalStateException`

Adds tests for other scenarios such as lists,bools,ints,doubles,floats and strings when present in the additional data.