### PR TITLE
Refactor to Eliminate Repetitive Mock Object Creation in RequestInformationTest (Issue #1374)

### DIFF
--- a/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
@@ -326,18 +326,22 @@ class RequestInformationTest {
         final URI uri = requestInfo.getUri();
         assertEquals("http://localhost/1,2", uri.toString());
     }
-    public final SerializationWriterFactory createMockSerializationWriterFactory(SerializationWriter writer){
+
+    public final SerializationWriterFactory createMockSerializationWriterFactory(
+            SerializationWriter writer) {
         final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
         when(factoryMock.getSerializationWriter(anyString())).thenReturn(writer);
-        return  factoryMock;
+        return factoryMock;
     }
-    public final RequestAdapter createMockRequestAdapter(SerializationWriterFactory factory){
+
+    public final RequestAdapter createMockRequestAdapter(SerializationWriterFactory factory) {
         final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
         when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factory);
-        return  requestAdapterMock;
+        return requestAdapterMock;
     }
-    public final RequestAdapter createMockRequestAdapter(SerializationWriter writer){
-        return  createMockRequestAdapter(createMockSerializationWriterFactory(writer));
+
+    public final RequestAdapter createMockRequestAdapter(SerializationWriter writer) {
+        return createMockRequestAdapter(createMockSerializationWriterFactory(writer));
     }
 }
 

--- a/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
@@ -326,14 +326,19 @@ class RequestInformationTest {
         final URI uri = requestInfo.getUri();
         assertEquals("http://localhost/1,2", uri.toString());
     }
-    public final RequestAdapter createMockRequestAdapter(SerializationWriter writerMock){
+    public final SerializationWriterFactory createMockSerializationWriterFactory(SerializationWriter writer){
         final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
-        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
-        RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
-        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
+        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writer);
+        return  factoryMock;
+    }
+    public final RequestAdapter createMockRequestAdapter(SerializationWriterFactory factory){
+        final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
+        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factory);
         return  requestAdapterMock;
     }
-
+    public final RequestAdapter createMockRequestAdapter(SerializationWriter writer){
+        return  createMockRequestAdapter(createMockSerializationWriterFactory(writer));
+    }
 }
 
 /** The messages in a mailbox or folder. Read-only. Nullable. */

--- a/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
@@ -188,10 +188,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.POST;
         requestInfo.urlTemplate = "http://localhost/users";
         final SerializationWriter writerMock = mock(SerializationWriter.class);
-        final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
-        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
-        final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
-        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
+        final RequestAdapter requestAdapterMock = createMockRequestAdapter(writerMock);
         requestInfo.setContentFromParsable(
                 requestAdapterMock, "application/json", new TestEntity());
 
@@ -207,10 +204,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.POST;
         requestInfo.urlTemplate = "http://localhost/users";
         final SerializationWriter writerMock = mock(SerializationWriter.class);
-        final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
-        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
-        final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
-        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
+        final RequestAdapter requestAdapterMock = createMockRequestAdapter(writerMock);
         requestInfo.setContentFromParsable(
                 requestAdapterMock, "application/json", new TestEntity[] {new TestEntity()});
 
@@ -225,10 +219,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.POST;
         requestInfo.urlTemplate = "http://localhost/users";
         final SerializationWriter writerMock = mock(SerializationWriter.class);
-        final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
-        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
-        final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
-        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
+        final RequestAdapter requestAdapterMock = createMockRequestAdapter(writerMock);
         requestInfo.setContentFromScalarCollection(
                 requestAdapterMock, "application/json", new String[] {"foo"});
 
@@ -243,10 +234,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.POST;
         requestInfo.urlTemplate = "http://localhost/users";
         final SerializationWriter writerMock = mock(SerializationWriter.class);
-        final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
-        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
-        final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
-        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
+        final RequestAdapter requestAdapterMock = createMockRequestAdapter(writerMock);
         requestInfo.setContentFromScalar(requestAdapterMock, "application/json", "foo");
 
         verify(writerMock, times(1)).writeStringValue(any(), anyString());
@@ -260,10 +248,7 @@ class RequestInformationTest {
         requestInfo.urlTemplate =
                 "http://localhost/{URITemplate}/ParameterMapping?IsCaseSensitive={IsCaseSensitive}";
         final SerializationWriter writerMock = mock(SerializationWriter.class);
-        final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
-        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
-        final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
-        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
+        final RequestAdapter requestAdapterMock = createMockRequestAdapter(writerMock);
 
         final MultipartBody multipartBody = new MultipartBody();
         multipartBody.requestAdapter = requestAdapterMock;
@@ -341,6 +326,14 @@ class RequestInformationTest {
         final URI uri = requestInfo.getUri();
         assertEquals("http://localhost/1,2", uri.toString());
     }
+    public final RequestAdapter createMockRequestAdapter(SerializationWriter writerMock){
+        final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
+        when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
+        RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
+        when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
+        return  requestAdapterMock;
+    }
+
 }
 
 /** The messages in a mailbox or folder. Read-only. Nullable. */


### PR DESCRIPTION
### Pull Request Title:
Refactor `RequestInformationTest` to Reduce Redundancy and Simplify Mock Creation

### Pull Request Description:
This pull request addresses issue #1374 by refactoring the `RequestInformationTest` class to eliminate redundant mock creations and simplify the testing code. Specifically, it introduces helper methods to centralize the creation and configuration of mocks for `RequestAdapter` and `SerializationWriterFactory`, reducing code duplication and enhancing readability.

#### Changes:

 **Added Methods**:
   - `createMockSerializationWriterFactory(SerializationWriter writer)`: Creates and configures a mock `SerializationWriterFactory` instance.
   - `createMockRequestAdapter(SerializationWriterFactory factory)`: Creates and configures a mock `RequestAdapter` instance using the provided mock factory.
   - `createMockRequestAdapter(SerializationWriter writer)`: Overload method that combines the creation of both mocks for convenience.

#### Here's the original issue:

---
Hi there!

While working with the`RequestInformationTest` class. I've noticed that there are 2 mock variables repeatedly created across various tests.  To simplify the code, I propose a small refactor to eliminate these redundancies, which could reduce the code by 20 lines.

1. **Mock `RequestAdapter` Creation**: Repeated 5 times.
2. **Mock `SerializationWriterFactory` Creation**: Repeated 5 times.

For instance, the mock creation logic is as follows:

```java
final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
when(factoryMock.getSerializationWriter(anyString())).thenReturn(writerMock);
final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factoryMock);
```


To eliminate redundancy, We can create two methods that can be called repeatedly,  `createMockSerializationWriterFactory` and `createMockRequestAdapter`:

```java
public final SerializationWriterFactory createMockSerializationWriterFactory(SerializationWriter writer){
    final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
    when(factoryMock.getSerializationWriter(anyString())).thenReturn(writer);
    return  factoryMock;
}
public final RequestAdapter createMockRequestAdapter(SerializationWriterFactory factory){
    final RequestAdapter requestAdapterMock = mock(RequestAdapter.class);
    when(requestAdapterMock.getSerializationWriterFactory()).thenReturn(factory);
    return  requestAdapterMock;
}
```
Using these methods, the refactored code becomes much cleaner:
```java
final SerializationWriterFactory factoryMock = createMockSerializationWriterFactory(writer);
final RequestAdapter requestAdapterMock = createMockRequestAdapter(factoryMock );
```

And for further improvement, we can overload `createMockRequestAdapter` for a more streamlined approach:
```java
public final RequestAdapter createMockRequestAdapter(SerializationWriter writer){
    return  createMockRequestAdapter(createMockSerializationWriterFactory(writer));
}
```
With this refactoring, mock creation and configuration can be done in a single line:

```java
final RequestAdapter requestAdapterMock = createMockRequestAdapter(writerMock);
```