### PR TITLE
Group dependabot updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     - "/components/http/okHttp"
   schedule:
     interval: daily
+    time: "09:00" # 9am UTC
   open-pull-requests-limit: 10
 - package-ecosystem: gradle
   directories:
@@ -24,6 +25,7 @@ updates:
     - "/components/http/okHttp/android"
   schedule:
     interval: daily
+    time: "10:00" # 10am UTC. Checked after the core modules to prevent duplicate PRs updating dependencies.gradle files
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,19 @@ version: 2
 updates:
 - package-ecosystem: gradle
   directories:
+    - "/"
+    - "/components/abstractions"
+    - "/components/serialization/form"
+    - "/components/serialization/json"
+    - "/components/serialization/text"
+    - "/components/serialization/multipart"
+    - "/components/authentication/azure"
+    - "/components/http/okHttp"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+- package-ecosystem: gradle
+  directories:
     - "/components/abstractions/android"
     - "/components/serialization/form/android"
     - "/components/serialization/json/android"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,72 +1,14 @@
 version: 2
 updates:
 - package-ecosystem: gradle
-  directory: "/components/abstractions"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/form"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/json"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/text"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/multipart"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/authentication/azure"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/http/okHttp"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/abstractions/android"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/form/android"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/json/android"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/text/android"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/serialization/multipart/android"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/authentication/azure/android"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: gradle
-  directory: "/components/http/okHttp/android"
+  directories:
+    - "/components/abstractions/android"
+    - "/components/serialization/form/android"
+    - "/components/serialization/json/android"
+    - "/components/serialization/text/android"
+    - "/components/serialization/multipart/android"
+    - "/components/authentication/azure/android"
+    - "/components/http/okHttp/android"
   schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,6 @@ sonar {
 
 subprojects {
     apply plugin: 'org.sonarqube'
-    apply plugin: 'com.github.spotbugs'
-    apply plugin: 'com.diffplug.spotless'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ sonar {
 }
 
 subprojects {
-	apply plugin: 'org.sonarqube'
+    apply plugin: 'org.sonarqube'
     apply plugin: 'com.github.spotbugs'
     apply plugin: 'com.diffplug.spotless'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id "java-library"
     id "org.sonarqube" version "4.4.1.3373"
+    id 'com.github.spotbugs' version '6.0.18'
+    id "com.diffplug.spotless" version "6.25.0"
 }
 
 sonar {
@@ -11,8 +13,11 @@ sonar {
 		property "sonar.coverage.jacoco.xmlReportPaths", "${project.projectDir}/components/**/reports/jacoco/test/jacocoTestReport.xml"
     }
 }
+
 subprojects {
 	apply plugin: 'org.sonarqube'
+    apply plugin: 'com.github.spotbugs'
+    apply plugin: 'com.diffplug.spotless'
 }
 
 repositories {

--- a/components/abstractions/build.gradle
+++ b/components/abstractions/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
+    id 'com.github.spotbugs'
+    id 'com.diffplug.spotless'
 }
 
 java {

--- a/components/abstractions/build.gradle
+++ b/components/abstractions/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '6.0.18'
-    id "com.diffplug.spotless" version "6.25.0"
 }
 
 java {

--- a/components/authentication/azure/build.gradle
+++ b/components/authentication/azure/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
+    id 'com.github.spotbugs'
+    id 'com.diffplug.spotless'
 }
 
 java {

--- a/components/authentication/azure/build.gradle
+++ b/components/authentication/azure/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '6.0.18'
-    id "com.diffplug.spotless" version "6.25.0"
 }
 
 java {

--- a/components/http/okHttp/build.gradle
+++ b/components/http/okHttp/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
+    id 'com.github.spotbugs'
+    id 'com.diffplug.spotless'
 }
 
 java {

--- a/components/http/okHttp/build.gradle
+++ b/components/http/okHttp/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '6.0.18'
-    id "com.diffplug.spotless" version "6.25.0"
 }
 
 java {

--- a/components/serialization/form/build.gradle
+++ b/components/serialization/form/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
+    id 'com.github.spotbugs'
+    id 'com.diffplug.spotless'
 }
 
 java {

--- a/components/serialization/form/build.gradle
+++ b/components/serialization/form/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '6.0.18'
-    id "com.diffplug.spotless" version "6.25.0"
 }
 
 java {

--- a/components/serialization/json/build.gradle
+++ b/components/serialization/json/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
+    id 'com.github.spotbugs'
+    id 'com.diffplug.spotless'
 }
 
 java {

--- a/components/serialization/json/build.gradle
+++ b/components/serialization/json/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '6.0.18'
-    id "com.diffplug.spotless" version "6.25.0"
 }
 
 java {

--- a/components/serialization/multipart/build.gradle
+++ b/components/serialization/multipart/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
+    id 'com.github.spotbugs'
+    id 'com.diffplug.spotless'
 }
 
 java {

--- a/components/serialization/multipart/build.gradle
+++ b/components/serialization/multipart/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '6.0.18'
-    id "com.diffplug.spotless" version "6.25.0"
 }
 
 java {

--- a/components/serialization/text/build.gradle
+++ b/components/serialization/text/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
+    id 'com.github.spotbugs'
+    id 'com.diffplug.spotless'
 }
 
 java {

--- a/components/serialization/text/build.gradle
+++ b/components/serialization/text/build.gradle
@@ -5,8 +5,6 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'jacoco'
-    id 'com.github.spotbugs' version '6.0.18'
-    id "com.diffplug.spotless" version "6.25.0"
 }
 
 java {


### PR DESCRIPTION
- Fixes scenarios where android specific dependencies need to be bumped across each project within one PR to prevent conflicts in versions across each module during testing e.g. https://github.com/microsoft/kiota-java/actions/runs/9899563697/job/27348715110 needing the same changes made across the board to build. Linting builds all android packages together.

- Prevents duplicate PRs bumping the same dependency file e.g. #1427 and #1429 since each /android project applies the root project's dependencies & [gradle](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#gradle) considers the dependencies files in the root projects as well during updates
