### PR TITLE
Automate releases from OSSRH to Maven Central

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     - "/components/serialization/multipart"
     - "/components/authentication/azure"
     - "/components/http/okHttp"
+    - "/components/bundle"
   schedule:
     interval: daily
     time: "09:00" # 9am UTC
@@ -23,6 +24,7 @@ updates:
     - "/components/serialization/multipart/android"
     - "/components/authentication/azure/android"
     - "/components/http/okHttp/android"
+    - "/components/bundle/android"
   schedule:
     interval: daily
     time: "10:00" # 10am UTC. Checked after the core modules to prevent duplicate PRs updating dependencies.gradle files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  PREVIEW_TASK: 'publishToSonatype'
+  PREVIEW_TASK: publishToSonatype
   PUBLISH_TASK: publishMavenPublicationToSonatypeRepository
 
 jobs:
@@ -18,6 +18,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: maven_central_snapshot
+    defaults:
+      run:
+        working-directory: ./
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK
@@ -34,14 +37,12 @@ jobs:
       env:
         ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
         OUTPUT_PATH: 'local.properties'
-      working-directory: ./
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh
       env:
         ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
         OUTPUT_PATH: 'secring.gpg'
-      working-directory: ./
     - name: Copy secring
       run: |
         Copy-Item secring.gpg components/abstractions/ -Verbose
@@ -53,16 +54,31 @@ jobs:
         Copy-Item secring.gpg components/http/okHttp/ -Verbose
         Copy-Item secring.gpg components/bundle/ -Verbose
       shell: pwsh
-      working-directory: ./
-    - name: Build with Gradle
-      run: ./gradlew --no-daemon build
-      working-directory: ./
-    - name: Publish Preview
+    - name: Publish to local Maven cache
+      run: ./gradlew --no-daemon publishToMavenLocal
+    - name: Get current SNAPSHOT version
+      shell: pwsh
+      run: |
+        $contents = Get-Content gradle.properties -Raw
+        $major = $contents | Select-String -Pattern 'mavenMajorVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
+        $minor = $contents | Select-String -Pattern 'mavenMinorVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
+        $patch = $contents | Select-String -Pattern 'mavenPatchVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
+        $version = "$major.$minor.$patch-SNAPSHOT"
+        echo "Current version is $version"
+        echo "PACKAGE_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+    - name: Inspect contents of local Maven cache
+      shell: pwsh
+      run: |
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-abstractions -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-authentication-azure -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-http-okHttp -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-form -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-json -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-text -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-multipart -Version $PACKAGE_VERSION
+    - name: Publish to Snapshot Repository
       run: ./gradlew --no-daemon $PREVIEW_TASK
       working-directory: ./
-    # - name: Validate Staging Repository contents
-    # - name: Close Staging Repository
-
 
 
   release-to-maven-central:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   PREVIEW_TASK: publishToSonatype
-  PUBLISH_TASK: publishMavenPublicationToSonatypeRepository
+  PUBLISH_TASK: publishToSonatype closeSonatypeStagingRepository
 
 jobs:
   release-to-maven-central-snapshot:
@@ -85,6 +85,9 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
+    defaults:
+      run:
+        working-directory: ./
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK
@@ -101,14 +104,12 @@ jobs:
       env:
         ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
         OUTPUT_PATH: 'local.properties'
-      working-directory: ./
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh
       env:
         ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
         OUTPUT_PATH: 'secring.gpg'
-      working-directory: ./
     - name: Copy secring
       run: |
         Copy-Item secring.gpg components/abstractions/ -Verbose
@@ -120,34 +121,44 @@ jobs:
         Copy-Item secring.gpg components/http/okHttp/ -Verbose
         Copy-Item secring.gpg components/bundle/ -Verbose
       shell: pwsh
-      working-directory: ./
-    - name: Build with Gradle
-      run: ./gradlew --no-daemon build
-      working-directory: ./
+    - name: Publish to local Maven cache for validation
+      run: ./gradlew --no-daemon publishToMavenLocal
+    - name: Get current SNAPSHOT version
+      shell: pwsh
+      run: |
+        $contents = Get-Content gradle.properties -Raw
+        $major = $contents | Select-String -Pattern 'mavenMajorVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
+        $minor = $contents | Select-String -Pattern 'mavenMinorVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
+        $patch = $contents | Select-String -Pattern 'mavenPatchVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
+        $version = "$major.$minor.$patch-SNAPSHOT"
+        echo "Current version is $version"
+        echo "PACKAGE_VERSION=$version" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+    - name: Inspect contents of local Maven cache
+      shell: pwsh
+      run: |
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-abstractions -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-authentication-azure -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-http-okHttp -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-form -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-json -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-text -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-multipart -Version $PACKAGE_VERSION
     - name: Publish Release abstractions #publishing all components at once often results in split staging repos which fails to release
       run: ./gradlew --no-daemon :components:abstractions:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Publish Release serialization form
       run: ./gradlew --no-daemon :components:serialization:form:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Publish Release serialization json
       run: ./gradlew --no-daemon :components:serialization:json:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Publish Release serialization text
       run: ./gradlew --no-daemon :components:serialization:text:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Publish Release serialization multipart
       run: ./gradlew --no-daemon :components:serialization:multipart:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Publish Release authentication azure
       run: ./gradlew --no-daemon :components:authentication:azure:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Publish Release okHttp
       run: ./gradlew --no-daemon :components:http:okHttp:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Publish Release bundle
       run: ./gradlew --no-daemon :components:bundle:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-      working-directory: ./
     - name: Release
       uses: anton-yurchenko/git-release@v6.0
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,7 @@ jobs:
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-json -Version $PACKAGE_VERSION
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-text -Version $PACKAGE_VERSION
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-multipart -Version $PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-bundle -Version $PACKAGE_VERSION
     - name: Publish Release abstractions #publishing all components at once often results in split staging repos which fails to release
       run: ./gradlew --no-daemon :components:abstractions:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
     - name: Publish Release serialization form

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  PREVIEW_TASK: publishMavenPublicationToSonatypeSnapshotRepository
+  PREVIEW_TASK: 'publishToSonatype'
   PUBLISH_TASK: publishMavenPublicationToSonatypeRepository
 
 jobs:
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup JDK
       uses: actions/setup-java@v4
-      with: 
+      with:
         java-version: 17
         distribution: 'temurin'
         cache: gradle
@@ -31,14 +31,14 @@ jobs:
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh
-      env:  
+      env:
         ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
         OUTPUT_PATH: 'local.properties'
       working-directory: ./
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh
-      env: 
+      env:
         ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
         OUTPUT_PATH: 'secring.gpg'
       working-directory: ./
@@ -60,6 +60,11 @@ jobs:
     - name: Publish Preview
       run: ./gradlew --no-daemon $PREVIEW_TASK
       working-directory: ./
+    # - name: Validate Staging Repository contents
+    # - name: Close Staging Repository
+
+
+
   release-to-maven-central:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
@@ -68,7 +73,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Setup JDK
       uses: actions/setup-java@v4
-      with: 
+      with:
         java-version: 17
         distribution: 'temurin'
         cache: gradle
@@ -77,14 +82,14 @@ jobs:
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh
-      env:  
+      env:
         ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties' 
+        OUTPUT_PATH: 'local.properties'
       working-directory: ./
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh
-      env: 
+      env:
         ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
         OUTPUT_PATH: 'secring.gpg'
       working-directory: ./

--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,7 @@ MigrationBackup/
 
 # build file
 build/
+
+local.properties
+
+*.gpg

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,15 @@ plugins {
     id "org.sonarqube" version "5.1.0.4882"
     id 'com.github.spotbugs' version '6.0.19'
     id "com.diffplug.spotless" version "6.25.0"
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 sonar {
     properties {
         property "sonar.projectKey", "microsoft_kiota-java"
-    	property "sonar.organization", "microsoft"
-    	property "sonar.host.url", "https://sonarcloud.io"
-		property "sonar.coverage.jacoco.xmlReportPaths", "${project.projectDir}/components/**/reports/jacoco/test/jacocoTestReport.xml"
+        property "sonar.organization", "microsoft"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.jacoco.xmlReportPaths", "${project.projectDir}/components/**/reports/jacoco/test/jacocoTestReport.xml"
     }
 }
 
@@ -21,3 +22,19 @@ subprojects {
 repositories {
     mavenCentral()
 }
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            if (project.rootProject.file('local.properties').exists()) {
+                Properties properties = new Properties()
+                properties.load(project.rootProject.file('local.properties').newDataInputStream())
+                username = properties.getProperty('sonatypeUsername')
+                password = properties.getProperty('sonatypePassword')
+            }
+        }
+    }
+}
+
+group = project.property('mavenGroupId')
+version = "${mavenMajorVersion}.${mavenMinorVersion}.${mavenPatchVersion}${mavenCentralSnapshotArtifactSuffix}"

--- a/components/abstractions/build.gradle
+++ b/components/abstractions/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/components/authentication/azure/build.gradle
+++ b/components/authentication/azure/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/components/bundle/build.gradle
+++ b/components/bundle/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/components/http/okHttp/build.gradle
+++ b/components/http/okHttp/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/components/serialization/form/build.gradle
+++ b/components/serialization/form/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/components/serialization/json/build.gradle
+++ b/components/serialization/json/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/components/serialization/multipart/build.gradle
+++ b/components/serialization/multipart/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/components/serialization/text/build.gradle
+++ b/components/serialization/text/build.gradle
@@ -102,35 +102,6 @@ publishing {
             }
         }
     }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/content/repositories/snapshots'
-            name = 'sonatypeSnapshot'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            name = 'sonatype'
-
-            credentials {
-                if (project.rootProject.file('local.properties').exists()) {
-                    Properties properties = new Properties()
-                    properties.load(project.rootProject.file('local.properties').newDataInputStream())
-                    username = properties.getProperty('sonatypeUsername')
-                    password = properties.getProperty('sonatypePassword')
-                }
-            }
-        }
-    }
 }
 
 signing {

--- a/scripts/ValidatePackageContents.ps1
+++ b/scripts/ValidatePackageContents.ps1
@@ -1,0 +1,60 @@
+# Checks that expected files are present & have contents after the publish process to the local cache
+param(
+  [Parameter(Mandatory=$true)][string] $ArtifactId,
+  [Parameter(Mandatory=$true)][string] $Version,
+  [Parameter()][string] $GroupId = "com.microsoft.kiota",
+  [Parameter()][string] $MavenLocalCachePath = "~" + [System.IO.Path]::DirectorySeparatorChar + ".m2" + [System.IO.Path]::DirectorySeparatorChar + "repository"
+)
+
+$groupIdPath = $GroupId -replace "\.", [System.IO.Path]::DirectorySeparatorChar
+$packagePath = Join-Path -Path $groupIdPath -ChildPath $ArtifactId
+$packageFullPath = Join-Path -Path $MavenLocalCachePath -ChildPath $packagePath -AdditionalChildPath $Version
+
+Write-Output "---------------------------------------------------"
+Write-Output "Validating package contents at $packageFullPath"
+
+if(-not (Test-Path -Path $packageFullPath)) {
+  Write-Output "Package not found in local cache."
+  exit 1
+}
+
+Write-Output "Package exists in local cache."
+
+$expectedFiles = @(
+  "-javadoc.jar",
+  "-javadoc.jar.asc",
+  "-sources.jar",
+  "-sources.jar.asc",
+  ".module",
+  ".module.asc",
+  ".pom",
+  ".pom.asc",
+  ".jar",
+  ".jar.asc"
+)
+
+foreach($file in $expectedFiles) {
+  $file = $ArtifactId + "-" + $Version + $file
+  $filePath = Join-Path -Path $packageFullPath -ChildPath $file
+  if(-not (Test-Path -Path $filePath)) {
+    Write-Output "Expected file $file not found in package."
+    exit 1
+  }
+  $fileSize = (Get-Item -Path $filePath).length
+  if($fileSize -eq 0) {
+    Write-Output "File $file is empty."
+    exit 1
+  }
+}
+
+$mavenMetadataFiles = Get-ChildItem -Path $packageFullPath -Filter "maven-metadata*.xml"
+if($mavenMetadataFiles.Count -eq 0) {
+  Write-Output "No maven-metadata*.xml files found in package."
+  exit 1
+}
+
+Write-Output "Package $ArtifactId is valid."
+Write-Output "---------------------------------------------------"
+exit 0
+
+


### PR DESCRIPTION
- Adds the [Gradle Nexus Publish Plugin](https://github.com/gradle-nexus/publish-plugin/?tab=readme-ov-file#gradle-nexus-publish-plugin) which allows closing and releasing from Nexus to Maven Central.
- Unfortunately it doesn't support dropping staging repositories. We also cannot download packages from staging repositories. This PR adds validation checks to ensure certain files are part of the package contents to be uploaded. The JARs are first published to the local maven cache & file contents inspected.
- For the prod release, we are only closing the staging repository using `closeSonatypeStagingRepository`. This will allow us to inspect the staging repository manually after these changes before we can switch to `closeAndReleaseSonatypeStagingRepository` with confidence that the automation works as expected.

part of https://github.com/microsoft/kiota-java/issues/1257