### PR TITLE
Add remove method to backing store

### DIFF
--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/BackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/BackingStore.java
@@ -63,6 +63,12 @@ public interface BackingStore {
     void unsubscribe(@Nonnull final String subscriptionId);
 
     /**
+     * Removes a value from the backing store, allowing removing a previously set value. Doesn't trigger any subscription.
+     * @param key The key for which the value should be removed
+     */
+    void remove(@Nonnull final String key);
+
+    /**
      * Clears the data stored in the backing store. Doesn't trigger any subscription.
      */
     void clear();

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -185,6 +185,11 @@ public class InMemoryBackingStore implements BackingStore {
         this.subscriptionStore.remove(subscriptionId);
     }
 
+    public void remove(@Nonnull String key) {
+        Objects.requireNonNull(key);
+        this.store.remove(key);
+    }
+
     @Nonnull public String subscribe(@Nonnull final TriConsumer<String, Object, Object> callback) {
         final String subscriptionId = UUID.randomUUID().toString();
         subscribe(subscriptionId, callback);

--- a/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
@@ -66,6 +66,19 @@ class InMemoryBackingStoreTest {
     }
 
     @Test
+    void RemovesValuePreviouslyInStore() {
+        // Arrange
+        var testBackingStore = new InMemoryBackingStore();
+        // Act
+        testBackingStore.set("name", "Peter Pan");
+        assertFalse(testBackingStore.enumerate().isEmpty());
+        testBackingStore.remove("name");
+        // Assert
+        assertNull(testBackingStore.get("name"));
+        assertTrue(testBackingStore.enumerate().isEmpty());
+    }
+
+    @Test
     void TestsBackingStoreEmbeddedInModel() {
         // Arrange dummy user with initialized backingstore
         var testUser = new TestEntity();


### PR DESCRIPTION
This remove method would be very useful to us.

Our use case is the following: We are mapping a user of our application to an Entra ID User object. This includes the manager field. But the manager cannot be updated using a PATCH call to the user, but has to be updated with a separate call. So we would still like to do the mapping into the manager field, but remove it before sending the actual PATCH request.