### PR TITLE
OSSRH release automation improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,12 @@ jobs:
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-json -Version $env:PACKAGE_VERSION
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-text -Version $env:PACKAGE_VERSION
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-multipart -Version $env:PACKAGE_VERSION
+        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-bundle -Version $env:PACKAGE_VERSION
     - name: Publish to Snapshot Repository
       run: ./gradlew --no-daemon $PREVIEW_TASK
       working-directory: ./
 
-
-  release-to-maven-central:
+  validate-package-contents:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
@@ -144,22 +144,311 @@ jobs:
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-text -Version $env:PACKAGE_VERSION
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-multipart -Version $env:PACKAGE_VERSION
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-bundle -Version $env:PACKAGE_VERSION
-    - name: Publish Release abstractions #publishing all components at once often results in split staging repos which fails to release
+
+  release-abstractions-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: validate-package-contents
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/abstractions/ -Verbose
+      shell: pwsh
+    - name: Publish Release abstractions
       run: ./gradlew --no-daemon :components:abstractions:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-    - name: Publish Release serialization form
-      run: ./gradlew --no-daemon :components:serialization:form:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-    - name: Publish Release serialization json
-      run: ./gradlew --no-daemon :components:serialization:json:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-    - name: Publish Release serialization text
-      run: ./gradlew --no-daemon :components:serialization:text:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-    - name: Publish Release serialization multipart
-      run: ./gradlew --no-daemon :components:serialization:multipart:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-authentication-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [validate-package-contents, release-abstractions-maven-central]
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/authentication/azure/ -Verbose
+      shell: pwsh
     - name: Publish Release authentication azure
       run: ./gradlew --no-daemon :components:authentication:azure:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-http-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [validate-package-contents, release-abstractions-maven-central]
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/http/okHttp/ -Verbose
+      shell: pwsh
     - name: Publish Release okHttp
       run: ./gradlew --no-daemon :components:http:okHttp:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-serialization-form-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [validate-package-contents, release-abstractions-maven-central]
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/serialization/form/ -Verbose
+      shell: pwsh
+    - name: Publish Release serialization form
+      run: ./gradlew --no-daemon :components:serialization:form:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-serialization-json-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [validate-package-contents, release-abstractions-maven-central]
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/serialization/json/ -Verbose
+      shell: pwsh
+    - name: Publish Release serialization json
+      run: ./gradlew --no-daemon :components:serialization:json:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-serialization-text-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [validate-package-contents, release-abstractions-maven-central]
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/serialization/text/ -Verbose
+      shell: pwsh
+    - name: Publish Release serialization text
+      run: ./gradlew --no-daemon :components:serialization:text:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-serialization-multipart-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [validate-package-contents, release-abstractions-maven-central]
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/serialization/multipart/ -Verbose
+      shell: pwsh
+    - name: Publish Release serialization multipart
+      run: ./gradlew --no-daemon :components:serialization:multipart:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-bundle-maven-central:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [
+      validate-package-contents,
+      release-abstractions-maven-central,
+      release-http-maven-central,
+      release-serialization-form-maven-central,
+      release-serialization-json-maven-central,
+      release-serialization-text-maven-central,
+      release-serialization-multipart-maven-central
+    ]
+    defaults:
+      run:
+        working-directory: ./
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: gradle
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
+        OUTPUT_PATH: 'local.properties'
+    - name: Download file
+      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
+      shell: pwsh
+      env:
+        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
+        OUTPUT_PATH: 'secring.gpg'
+    - name: Copy secring
+      run: |
+        Copy-Item secring.gpg components/bundle/ -Verbose
+      shell: pwsh
     - name: Publish Release bundle
       run: ./gradlew --no-daemon :components:bundle:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+
+  release-to-github:
+    if: contains(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: maven_central
+    needs: [
+      release-abstractions-maven-central,
+      release-authentication-maven-central,
+      release-http-maven-central,
+      release-serialization-form-maven-central,
+      release-serialization-json-maven-central,
+      release-serialization-text-maven-central,
+      release-serialization-multipart-maven-central,
+      release-bundle-maven-central
+    ]
+    steps:
+    - uses: actions/checkout@v4
     - name: Release
       uses: anton-yurchenko/git-release@v6.0
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   PREVIEW_TASK: publishToSonatype
-  PUBLISH_TASK: publishToSonatype closeSonatypeStagingRepository
+  PUBLISH_TASK: publishToSonatype closeAndReleaseSonatypeStagingRepository
   JAVA_VERSION: 21
   JAVA_DIST: 'temurin'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -457,3 +457,5 @@ jobs:
         PRE_RELEASE: "false"
         CHANGELOG_FILE: "CHANGELOG.md"
         ALLOW_EMPTY_CHANGELOG: "true"
+      with:
+        args: components/**/build/libs/*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-multipart -Version $env:PACKAGE_VERSION
         .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-bundle -Version $env:PACKAGE_VERSION
 
-  release-abstractions-maven-central:
+  release-maven-central:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
@@ -132,6 +132,18 @@ jobs:
     defaults:
       run:
         working-directory: ./
+    strategy:
+      matrix:
+        component-path: [
+          abstractions,
+          authentication/azure,
+          http/okHttp,
+          serialization/form,
+          serialization/json,
+          serialization/text,
+          serialization/multipart,
+          bundle
+        ]
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK
@@ -154,255 +166,12 @@ jobs:
         OUTPUT_PATH: 'secring.gpg'
     - name: Copy secring
       run: |
-        Copy-Item secring.gpg components/abstractions/ -Verbose
+        Copy-Item secring.gpg components/${{ matrix.component-path }}/ -Verbose
       shell: pwsh
     - name: Publish Release abstractions
-      run: ./gradlew --no-daemon :components:abstractions:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-
-  release-authentication-maven-central:
-    if: contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: maven_central
-    needs: validate-package-contents
-    defaults:
-      run:
-        working-directory: ./
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: ${{ env.JAVA_DIST}}
-        cache: gradle
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties'
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
-        OUTPUT_PATH: 'secring.gpg'
-    - name: Copy secring
       run: |
-        Copy-Item secring.gpg components/authentication/azure/ -Verbose
-      shell: pwsh
-    - name: Publish Release authentication azure
-      run: ./gradlew --no-daemon :components:authentication:azure:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-
-  release-http-maven-central:
-    if: contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: maven_central
-    needs: validate-package-contents
-    defaults:
-      run:
-        working-directory: ./
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: ${{ env.JAVA_DIST}}
-        cache: gradle
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties'
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
-        OUTPUT_PATH: 'secring.gpg'
-    - name: Copy secring
-      run: |
-        Copy-Item secring.gpg components/http/okHttp/ -Verbose
-      shell: pwsh
-    - name: Publish Release okHttp
-      run: ./gradlew --no-daemon :components:http:okHttp:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-
-  release-serialization-form-maven-central:
-    if: contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: maven_central
-    needs: validate-package-contents
-    defaults:
-      run:
-        working-directory: ./
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: ${{ env.JAVA_DIST}}
-        cache: gradle
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties'
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
-        OUTPUT_PATH: 'secring.gpg'
-    - name: Copy secring
-      run: |
-        Copy-Item secring.gpg components/serialization/form/ -Verbose
-      shell: pwsh
-    - name: Publish Release serialization form
-      run: ./gradlew --no-daemon :components:serialization:form:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-
-  release-serialization-json-maven-central:
-    if: contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: maven_central
-    needs: validate-package-contents
-    defaults:
-      run:
-        working-directory: ./
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: ${{ env.JAVA_DIST}}
-        cache: gradle
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties'
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
-        OUTPUT_PATH: 'secring.gpg'
-    - name: Copy secring
-      run: |
-        Copy-Item secring.gpg components/serialization/json/ -Verbose
-      shell: pwsh
-    - name: Publish Release serialization json
-      run: ./gradlew --no-daemon :components:serialization:json:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-
-  release-serialization-text-maven-central:
-    if: contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: maven_central
-    needs: validate-package-contents
-    defaults:
-      run:
-        working-directory: ./
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: ${{ env.JAVA_DIST}}
-        cache: gradle
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties'
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
-        OUTPUT_PATH: 'secring.gpg'
-    - name: Copy secring
-      run: |
-        Copy-Item secring.gpg components/serialization/text/ -Verbose
-      shell: pwsh
-    - name: Publish Release serialization text
-      run: ./gradlew --no-daemon :components:serialization:text:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-
-  release-serialization-multipart-maven-central:
-    if: contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: maven_central
-    needs: validate-package-contents
-    defaults:
-      run:
-        working-directory: ./
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: ${{ env.JAVA_DIST}}
-        cache: gradle
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties'
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
-        OUTPUT_PATH: 'secring.gpg'
-    - name: Copy secring
-      run: |
-        Copy-Item secring.gpg components/serialization/multipart/ -Verbose
-      shell: pwsh
-    - name: Publish Release serialization multipart
-      run: ./gradlew --no-daemon :components:serialization:multipart:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
-
-  release-bundle-maven-central:
-    if: contains(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: maven_central
-    needs: validate-package-contents
-    defaults:
-      run:
-        working-directory: ./
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup JDK
-      uses: actions/setup-java@v4
-      with:
-        java-version: ${{ env.JAVA_VERSION }}
-        distribution: ${{ env.JAVA_DIST}}
-        cache: gradle
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.LOCAL_PROPERTIES }}
-        OUTPUT_PATH: 'local.properties'
-    - name: Download file
-      run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
-      shell: pwsh
-      env:
-        ENCODED_VALUE: ${{ secrets.SECRING_GPG }}
-        OUTPUT_PATH: 'secring.gpg'
-    - name: Copy secring
-      run: |
-        Copy-Item secring.gpg components/bundle/ -Verbose
-      shell: pwsh
-    - name: Publish Release bundle
-      run: ./gradlew --no-daemon :components:bundle:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+        componentTaskPath=$(echo ${{ matrix.component-path }} | tr / :)
+        ./gradlew --no-daemon :components:$componentTaskPath:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
 
   release-to-github:
     if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,6 @@ jobs:
   release-to-github:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    environment: maven_central
     steps:
     - uses: actions/checkout@v4
     - name: Setup JDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: maven_central_snapshot
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./
@@ -56,37 +57,13 @@ jobs:
         Copy-Item secring.gpg components/http/okHttp/ -Verbose
         Copy-Item secring.gpg components/bundle/ -Verbose
       shell: pwsh
-    - name: Publish to local Maven cache
-      run: ./gradlew --no-daemon publishToMavenLocal
-    - name: Get current SNAPSHOT version
-      shell: pwsh
-      run: |
-        $contents = Get-Content gradle.properties -Raw
-        $major = $contents | Select-String -Pattern 'mavenMajorVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
-        $minor = $contents | Select-String -Pattern 'mavenMinorVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
-        $patch = $contents | Select-String -Pattern 'mavenPatchVersion = ([0-9]+)' | ForEach-Object { $_.Matches.Groups[1].Value }
-        $version = "$major.$minor.$patch-SNAPSHOT"
-        echo "Current version is $version"
-        echo "PACKAGE_VERSION=$version" >> $Env:GITHUB_ENV
-    - name: Inspect contents of local Maven cache
-      shell: pwsh
-      run: |
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-abstractions -Version $env:PACKAGE_VERSION
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-authentication-azure -Version $env:PACKAGE_VERSION
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-http-okHttp -Version $env:PACKAGE_VERSION
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-form -Version $env:PACKAGE_VERSION
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-json -Version $env:PACKAGE_VERSION
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-text -Version $env:PACKAGE_VERSION
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-serialization-multipart -Version $env:PACKAGE_VERSION
-        .\scripts\ValidatePackageContents.ps1 -ArtifactId microsoft-kiota-bundle -Version $env:PACKAGE_VERSION
     - name: Publish to Snapshot Repository
       run: ./gradlew --no-daemon $PREVIEW_TASK
       working-directory: ./
 
   validate-package-contents:
-    if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    environment: maven_central
+    environment: ${{ contains(github.ref, 'refs/tags/v') && 'maven_central' || 'maven_central_snapshot' }}
     defaults:
       run:
         working-directory: ./
@@ -186,7 +163,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [validate-package-contents, release-abstractions-maven-central]
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./
@@ -221,7 +198,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [validate-package-contents, release-abstractions-maven-central]
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./
@@ -256,7 +233,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [validate-package-contents, release-abstractions-maven-central]
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./
@@ -291,7 +268,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [validate-package-contents, release-abstractions-maven-central]
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./
@@ -326,7 +303,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [validate-package-contents, release-abstractions-maven-central]
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./
@@ -361,7 +338,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [validate-package-contents, release-abstractions-maven-central]
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./
@@ -396,15 +373,7 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [
-      validate-package-contents,
-      release-abstractions-maven-central,
-      release-http-maven-central,
-      release-serialization-form-maven-central,
-      release-serialization-json-maven-central,
-      release-serialization-text-maven-central,
-      release-serialization-multipart-maven-central
-    ]
+    needs: validate-package-contents
     defaults:
       run:
         working-directory: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 env:
   PREVIEW_TASK: publishToSonatype
   PUBLISH_TASK: publishToSonatype closeSonatypeStagingRepository
+  JAVA_VERSION: 21
+  JAVA_DIST: 'temurin'
 
 jobs:
   release-to-maven-central-snapshot:
@@ -26,8 +28,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST }}
         cache: gradle
     - name: Detect Secrets
       uses: RobertFischer/detect-secrets-action@v2.0.0
@@ -93,8 +95,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Detect Secrets
       uses: RobertFischer/detect-secrets-action@v2.0.0
@@ -158,8 +160,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
@@ -193,8 +195,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
@@ -228,8 +230,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
@@ -263,8 +265,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
@@ -298,8 +300,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
@@ -333,8 +335,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
@@ -368,8 +370,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
@@ -411,8 +413,8 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
-        distribution: 'temurin'
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
         cache: gradle
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -408,18 +408,16 @@ jobs:
     if: contains(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: maven_central
-    needs: [
-      release-abstractions-maven-central,
-      release-authentication-maven-central,
-      release-http-maven-central,
-      release-serialization-form-maven-central,
-      release-serialization-json-maven-central,
-      release-serialization-text-maven-central,
-      release-serialization-multipart-maven-central,
-      release-bundle-maven-central
-    ]
     steps:
     - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DIST}}
+        cache: gradle
+    - name: Build with Gradle
+      run: ./gradlew --no-daemon build
     - name: Release
       uses: anton-yurchenko/git-release@v6.0
       env:


### PR DESCRIPTION
- Adds `closeAndReleaseSonatypeStagingRepository` to the publish task to fully automate closing and release from staging repositories to maven central
- Makes each package's publish step a separate job so that each can be retried in isolation in case of a failure in the deployment process
- Adds JARs to the GitHub release assets


closes https://github.com/microsoft/kiota-java/issues/1257