### PR TITLE
Add secrets scanning baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,10 @@ jobs:
         java-version: 17
         distribution: 'temurin'
         cache: gradle
-    - name: Detect Secrets
-      uses: RobertFischer/detect-secrets-action@v2.0.0
+    - name: Detect secrets
+      run: |
+        pip install detect-secrets
+        git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
     - name: Build with Gradle
       run: ./gradlew --no-daemon build -Pjava8=true
     - name: Upload Unit Test Results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: ${{ env.JAVA_DIST }}
         cache: gradle
-    - name: Detect Secrets
-      uses: RobertFischer/detect-secrets-action@v2.0.0
+    - name: Detect secrets
+      run: |
+        pip install detect-secrets
+        git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh
@@ -75,8 +77,10 @@ jobs:
         java-version: ${{ env.JAVA_VERSION }}
         distribution: ${{ env.JAVA_DIST}}
         cache: gradle
-    - name: Detect Secrets
-      uses: RobertFischer/detect-secrets-action@v2.0.0
+    - name: Detect secrets
+      run: |
+        pip install detect-secrets
+        git ls-files -z | xargs -0 detect-secrets-hook --baseline .secrets.baseline
     - name: Download file
       run: .\scripts\decodeAndWrite.ps1 -encodedValue $env:ENCODED_VALUE -outputPath $env:OUTPUT_PATH
       shell: pwsh

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,131 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2024-08-13T12:49:40Z"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,14 +29,6 @@ mavenMinorVersion = 2
 mavenPatchVersion = 0
 mavenArtifactSuffix =
 
-#These values are used to run functional tests
-#If you wish to run the functional tests, edit the gradle.properties
-#file in your user directory instead of adding them here.
-#ex: C:\Users\username\.gradle\gradle.properties
-ClientId="CLIENT_ID"
-Username="USERNAME"
-Password="PASSWORD"
-
 #enable mavenCentralPublishingEnabled to publish to maven central
 mavenCentralSnapshotArtifactSuffix = -SNAPSHOT
 mavenCentralPublishingEnabled=false


### PR DESCRIPTION
Configures [`detect-secrets`](https://github.com/Yelp/detect-secrets)
- Adds baseline file for secrets scanning
- Updates workflows to use fail on secrets detection
