### PR TITLE
Ensure reading request body does not drain the input stream if stream is not resettable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2024-08-22
+
+### Changed
+
+- Ensure interceptors don't drain request body stream before network call [#2037](https://github.com/microsoftgraph/msgraph-sdk-java/issues/2037)
+
 ## [1.2.0] - 2024-08-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Read more about Kiota [here](https://github.com/microsoft/kiota/blob/main/README
 In `build.gradle` in the `dependencies` section:
 
 ```Groovy
-implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:1.2.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.2.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.2.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.2.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.2.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.2.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.2.0'
-implementation 'com.microsoft.kiota:microsoft-kiota-bundle:1.2.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-abstractions:1.3.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-authentication-azure:1.3.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-http-okHttp:1.3.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-json:1.3.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-text:1.3.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-form:1.3.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-serialization-multipart:1.3.0'
+implementation 'com.microsoft.kiota:microsoft-kiota-bundle:1.3.0'
 implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 ```
 
@@ -40,37 +40,37 @@ In `pom.xml` in the `dependencies` section:
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-abstractions</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-authentication-azure</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-http-okHttp</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-json</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-text</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-form</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.microsoft.kiota</groupId>
       <artifactId>microsoft-kiota-serialization-multipart</artifactId>
-      <version>1.2.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>

--- a/components/http/okHttp/gradle/dependencies.gradle
+++ b/components/http/okHttp/gradle/dependencies.gradle
@@ -6,6 +6,7 @@ dependencies {
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
 
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -900,6 +900,11 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                                 }
 
                                 @Override
+                                public boolean isOneShot() {
+                                    return true;
+                                }
+
+                                @Override
                                 public long contentLength() throws IOException {
                                     final Set<String> contentLength =
                                             requestInfo.headers.getOrDefault(

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -901,7 +901,7 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
 
                                 @Override
                                 public boolean isOneShot() {
-                                    return true;
+                                    return !requestInfo.content.markSupported();
                                 }
 
                                 @Override
@@ -928,6 +928,9 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                                 @Override
                                 public void writeTo(@Nonnull BufferedSink sink) throws IOException {
                                     sink.writeAll(Okio.source(requestInfo.content));
+                                    if (!isOneShot()) {
+                                        requestInfo.content.reset();
+                                    }
                                 }
                             };
 

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/options/UserAgentHandlerOption.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/options/UserAgentHandlerOption.java
@@ -13,7 +13,7 @@ public class UserAgentHandlerOption implements RequestOption {
 
     private boolean enabled = true;
     @Nonnull private String productName = "kiota-java";
-    @Nonnull private String productVersion = "1.2.0";
+    @Nonnull private String productVersion = "1.3.0";
 
     /**
      * Gets the product name to be used in the user agent header

--- a/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
+++ b/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java
@@ -493,7 +493,7 @@ public class OkHttpRequestAdapterTest {
         requestInformation.setResponseHandler(nativeResponseHandler);
 
         var mockEntity = creatMockEntity();
-        requestAdapter.send(requestInformation, null, (node) -> mockEntity);
+        requestAdapter.send(requestInformation, null, node -> mockEntity);
         var nativeResponse = (Response) nativeResponseHandler.getValue();
         assertNotNull(nativeResponse);
         assertEquals(requestBodyJson, nativeResponse.body().source().readUtf8());
@@ -528,7 +528,7 @@ public class OkHttpRequestAdapterTest {
         try (FileInputStream content = new FileInputStream(testFile)) {
             requestInformation.setStreamContent(content, "application/octet-stream");
             var mockEntity = creatMockEntity();
-            requestAdapter.send(requestInformation, null, (node) -> mockEntity);
+            requestAdapter.send(requestInformation, null, node -> mockEntity);
             var nativeResponse = (Response) nativeResponseHandler.getValue();
             assertNotNull(nativeResponse);
             assertEquals(contentLength, nativeResponse.body().source().readByteArray().length);

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ org.gradle.caching=true
 
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
-mavenMinorVersion = 2
+mavenMinorVersion = 3
 mavenPatchVersion = 0
 mavenArtifactSuffix =
 


### PR DESCRIPTION
We currently override the Request body's `writeTo` method which was not resetting the input stream after the body is written e.g. by a logging interceptor. The network call would find an empty request body.

This PR determines if the request body is resettable & configures [`isOneShot()`](https://square.github.io/okhttp/5.x/okhttp/okhttp3/-request-body/is-one-shot.html) to prevent non-resettable streams from being drained by logging middleware.

closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/2037