### PR TITLE
Fix Java 21 Build issues

### DIFF
--- a/.github/workflows/api-level-lint.yml
+++ b/.github/workflows/api-level-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
           cache: gradle
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3.2.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup JDK
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'temurin'
         cache: gradle
     - name: Detect secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 env:
   PREVIEW_TASK: publishToSonatype
   PUBLISH_TASK: publishToSonatype closeAndReleaseSonatypeStagingRepository
-  JAVA_VERSION: 21
+  JAVA_VERSION: 17
   JAVA_DIST: 'temurin'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 env:
   PREVIEW_TASK: publishToSonatype
   PUBLISH_TASK: publishToSonatype closeAndReleaseSonatypeStagingRepository
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DIST: 'temurin'
 
 jobs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
-          cache: gradle   
+          cache: gradle
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/components/abstractions/gradle/dependencies.gradle
+++ b/components/abstractions/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.0'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/components/authentication/azure/gradle/dependencies.gradle
+++ b/components/authentication/azure/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.0'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 
 
     // Use JUnit Jupiter Engine for testing.

--- a/components/bundle/gradle/dependencies.gradle
+++ b/components/bundle/gradle/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 

--- a/components/http/okHttp/gradle/dependencies.gradle
+++ b/components/http/okHttp/gradle/dependencies.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
     testImplementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
 
 

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
@@ -190,10 +190,10 @@ class JsonSerializationWriterTests {
         // Assert
         var expectedString =
                 "{\"id\":\"1\","
-                    + "\"location\":{\"hasReception\":true,\"address\":{\"state\":\"Washington\",\"city\":\"Redmond\",\"street\":\"NE"
+                    + "\"location\":{\"hasReception\":true,\"coordinates\":{\"latitude\":47.641942,\"longitude\":-122.127222},"
+                    + "\"address\":{\"state\":\"Washington\",\"city\":\"Redmond\",\"street\":\"NE"
                     + " 36th St\",\"postalCode\":\"98052\"},\"displayName\":\"Microsoft Building"
-                    + " 92\",\"floorCount\":50,\"contact\":null,\"coordinates\":{\"latitude\":47.641942,\"longitude\":-122.127222}},"
-                    + "\"keywords\":["
+                    + " 92\",\"floorCount\":50,\"contact\":null},\"keywords\":["
                     + "{\"wssId\":345345345,\"label\":\"Keyword1\",\"termGuid\":\"10e9cc83-b5a4-4c8d-8dab-4ada1252dd70\",\"created\":\"2023-07-26T10:41:26Z\"},"
                     + "{\"wssId\":345345345,\"label\":\"Keyword2\",\"termGuid\":\"2cae6c6a-9bb8-4a78-afff-81b88e735fef\",\"created\":\"2023-07-26T10:51:26Z\"}],"
                     + "\"extra\":{\"createdDateTime\":\"2024-01-15T00:00:00+00:00\"}}";

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java
@@ -53,15 +53,17 @@ class JsonSerializationWriterTests {
                 .getAdditionalData()
                 .put("aliases", aliases); // place a collection in the additional data
 
-        var jsonSerializer = new JsonSerializationWriter();
-        jsonSerializer.writeObjectValue("", testEntity);
-        var contentStream = jsonSerializer.getSerializedContent();
-        var serializedJsonString = new String(Compatibility.readAllBytes(contentStream), "UTF-8");
-        // Assert
-        var expectedString =
-                "{\"aliases\":[\"alias1\",\"alias2\"],\"nickName\":\"Peter"
-                    + " Pan\",\"hasDependents\":true,\"accountBalance\":330.7,\"reportsCount\":4,\"averageScore\":78.142}";
-        assertEquals(expectedString, serializedJsonString);
+        try (final var jsonSerializer = new JsonSerializationWriter()) {
+            jsonSerializer.writeObjectValue("", testEntity);
+            var contentStream = jsonSerializer.getSerializedContent();
+            var serializedJsonString =
+                    new String(Compatibility.readAllBytes(contentStream), "UTF-8");
+            // Assert
+            var expectedString =
+                    "{\"aliases\":[\"alias1\",\"alias2\"],\"nickName\":\"Peter"
+                        + " Pan\",\"hasDependents\":true,\"accountBalance\":330.7,\"reportsCount\":4,\"averageScore\":78.142}";
+            assertEquals(expectedString, serializedJsonString);
+        }
     }
 
     @Test
@@ -79,14 +81,16 @@ class JsonSerializationWriterTests {
                 .getAdditionalData()
                 .put("manager", managerAdditionalData); // place a parsable in the addtionaldata
 
-        var jsonSerializer = new JsonSerializationWriter();
-        jsonSerializer.writeObjectValue("", testEntity);
-        var contentStream = jsonSerializer.getSerializedContent();
-        var serializedJsonString = new String(Compatibility.readAllBytes(contentStream), "UTF-8");
-        // Assert
-        var expectedString =
-                "{\"id\":\"test_id\",\"phones\":[\"123456789\"],\"manager\":{\"id\":\"manager_id\",\"myEnum\":\"VALUE1\"}}";
-        assertEquals(expectedString, serializedJsonString);
+        try (final var jsonSerializer = new JsonSerializationWriter()) {
+            jsonSerializer.writeObjectValue("", testEntity);
+            var contentStream = jsonSerializer.getSerializedContent();
+            var serializedJsonString =
+                    new String(Compatibility.readAllBytes(contentStream), "UTF-8");
+            // Assert
+            var expectedString =
+                    "{\"id\":\"test_id\",\"phones\":[\"123456789\"],\"manager\":{\"id\":\"manager_id\",\"myEnum\":\"VALUE1\"}}";
+            assertEquals(expectedString, serializedJsonString);
+        }
     }
 
     @Test
@@ -182,21 +186,23 @@ class JsonSerializationWriterTests {
                                     }
                                 }));
 
-        var jsonSerializer = new JsonSerializationWriter();
-        jsonSerializer.writeObjectValue("", untypedTestEntity);
-        var contentStream = jsonSerializer.getSerializedContent();
-        var serializedJsonString = new String(Compatibility.readAllBytes(contentStream), "UTF-8");
+        try (final var jsonSerializer = new JsonSerializationWriter()) {
+            jsonSerializer.writeObjectValue("", untypedTestEntity);
+            var contentStream = jsonSerializer.getSerializedContent();
+            var serializedJsonString =
+                    new String(Compatibility.readAllBytes(contentStream), "UTF-8");
 
-        // Assert
-        var expectedString =
-                "{\"id\":\"1\","
-                    + "\"location\":{\"hasReception\":true,\"coordinates\":{\"latitude\":47.641942,\"longitude\":-122.127222},"
-                    + "\"address\":{\"state\":\"Washington\",\"city\":\"Redmond\",\"street\":\"NE"
-                    + " 36th St\",\"postalCode\":\"98052\"},\"displayName\":\"Microsoft Building"
-                    + " 92\",\"floorCount\":50,\"contact\":null},\"keywords\":["
-                    + "{\"wssId\":345345345,\"label\":\"Keyword1\",\"termGuid\":\"10e9cc83-b5a4-4c8d-8dab-4ada1252dd70\",\"created\":\"2023-07-26T10:41:26Z\"},"
-                    + "{\"wssId\":345345345,\"label\":\"Keyword2\",\"termGuid\":\"2cae6c6a-9bb8-4a78-afff-81b88e735fef\",\"created\":\"2023-07-26T10:51:26Z\"}],"
-                    + "\"extra\":{\"createdDateTime\":\"2024-01-15T00:00:00+00:00\"}}";
-        assertEquals(expectedString, serializedJsonString);
+            // Assert
+            var expectedString =
+                    "{\"id\":\"1\","
+                        + "\"location\":{\"hasReception\":true,\"coordinates\":{\"latitude\":47.641942,\"longitude\":-122.127222},"
+                        + "\"address\":{\"state\":\"Washington\",\"city\":\"Redmond\",\"street\":\"NE"
+                        + " 36th St\",\"postalCode\":\"98052\"},\"displayName\":\"Microsoft"
+                        + " Building 92\",\"floorCount\":50,\"contact\":null},\"keywords\":["
+                        + "{\"wssId\":345345345,\"label\":\"Keyword1\",\"termGuid\":\"10e9cc83-b5a4-4c8d-8dab-4ada1252dd70\",\"created\":\"2023-07-26T10:41:26Z\"},"
+                        + "{\"wssId\":345345345,\"label\":\"Keyword2\",\"termGuid\":\"2cae6c6a-9bb8-4a78-afff-81b88e735fef\",\"created\":\"2023-07-26T10:51:26Z\"}],"
+                        + "\"extra\":{\"createdDateTime\":\"2024-01-15T00:00:00+00:00\"}}";
+            assertEquals(expectedString, serializedJsonString);
+        }
     }
 }

--- a/components/serialization/multipart/gradle/dependencies.gradle
+++ b/components/serialization/multipart/gradle/dependencies.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
-    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.12.0'
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'


### PR DESCRIPTION
Fixes failing builds in [release](https://github.com/microsoft/kiota-java/actions/runs/10509355140/job/29115355499) workflow

- Fixes failing tests caused by our previous dependency on `mockito-inline` which transitively installed [`byte-buddy-agent:1.14.1`](https://central.sonatype.com/artifact/net.bytebuddy/byte-buddy-agent/1.14.1). This version of byte-buddy agent [doesn't support Java 21](https://github.com/raphw/byte-buddy/issues/1396#issuecomment-1763717640). `mockito-inline` was deprecated after `5.3.0` of `mockito-core`. Changing to `mockito-core`'s latest version allows us to transitively get a Java 21 compatible `byte-buddy` dependency.
- Updates workflows to use Java 21

Pending:
- Change serialization validation [here](https://github.com/microsoft/kiota-java/blob/main/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonSerializationWriterTests.java#L191) since order of set entries is not guaranteed during [serializing](https://github.com/microsoft/kiota-java/blob/main/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonSerializationWriter.java#L359). Java 17 & 21 produce different orderings.