### PR TITLE
Fix undefined behaviour in backing store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix InMemoryBackingStore by preventing updates to underlying store's Map while iterating over it [#2106](https://github.com/microsoftgraph/msgraph-sdk-java/issues/2106)
- - Use concurrent HashMap for In memory backing store registry to avoid race conditions.
+- Use concurrent HashMap for In memory backing store registry to avoid race conditions.
 
 ## [1.3.0] - 2024-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix InMemoryBackingStore by preventing updates to underlying store's Map while iterating over it [#2106](https://github.com/microsoftgraph/msgraph-sdk-java/issues/2106)
+ - Use concurrent HashMap for In memory backing store registry to avoid race conditions.
 
 ## [1.3.0] - 2024-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2024-09-11
+
+### Changed
+
+- Fix InMemoryBackingStore by preventing updates to underlying store's Map while iterating over it [#2106](https://github.com/microsoftgraph/msgraph-sdk-java/issues/2106)
+
 ## [1.3.0] - 2024-08-22
 
 ### Changed

--- a/components/abstractions/spotBugsExcludeFilter.xml
+++ b/components/abstractions/spotBugsExcludeFilter.xml
@@ -52,7 +52,10 @@ xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubu
 	</Match>
     <Match>
         <Bug pattern="EI_EXPOSE_REP" />
-        <Class name="com.microsoft.kiota.TestEntity" />
+        <Or>
+            <Class name="com.microsoft.kiota.TestEntity" />
+            <Class name="com.microsoft.kiota.BaseCollectionPaginationCountResponse" />
+        </Or>
     </Match>
     <Match>
         <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE" />

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -80,7 +80,8 @@ public class InMemoryBackingStore implements BackingStore {
                             BackedModel backedModel = (BackedModel) item;
                             backedModel
                                     .getBackingStore()
-                                    .setIsInitializationCompleted(value); // propagate initialization
+                                    .setIsInitializationCompleted(
+                                            value); // propagate initialization
                         }
                     }
                 }
@@ -112,9 +113,7 @@ public class InMemoryBackingStore implements BackingStore {
                     for (final Object item : items) {
                         if (item instanceof BackedModel) {
                             BackedModel backedModel = (BackedModel) item;
-                            backedModel
-                                    .getBackingStore()
-                                    .setReturnOnlyChangedValues(value);
+                            backedModel.getBackingStore().setReturnOnlyChangedValues(value);
                         }
                     }
                 }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -235,8 +235,8 @@ public class InMemoryBackingStore implements BackingStore {
     }
 
     private void ensureCollectionPropertiesAreConsistent() {
-        HashMap<String, Object> currentStoreDirtyCollections = new HashMap<>();
-        List<BackedModel> nestedBackedModelsToEnumerate = new ArrayList<>();
+        final HashMap<String, Object> currentStoreDirtyCollections = new HashMap<>();
+        final List<BackedModel> nestedBackedModelsToEnumerate = new ArrayList<>();
 
         for (final Map.Entry<String, Pair<Boolean, Object>> entry : this.store.entrySet()) {
             final Pair<Boolean, Object> wrapper = entry.getValue();
@@ -260,7 +260,7 @@ public class InMemoryBackingStore implements BackingStore {
         }
 
         // Only update parent properties that haven't been marked as dirty by the nested models
-        for (Map.Entry<String, Object> entry : currentStoreDirtyCollections.entrySet()) {
+        for (final Map.Entry<String, Object> entry : currentStoreDirtyCollections.entrySet()) {
             // Always set() if there were no nested models
             if (nestedBackedModelsToEnumerate.isEmpty()) {
                 set(entry.getKey(), entry.getValue());

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -58,7 +58,7 @@ public class InMemoryBackingStore implements BackingStore {
         ensureCollectionPropertiesAreConsistent();
         for (final Map.Entry<String, Pair<Boolean, Object>> entry : this.store.entrySet()) {
             final Pair<Boolean, Object> wrapper = entry.getValue();
-            Pair<Boolean, Object> updatedValue = new Pair<>(!value, wrapper.getValue1());
+            final Pair<Boolean, Object> updatedValue = new Pair<>(!value, wrapper.getValue1());
             entry.setValue(updatedValue);
 
             if (wrapper.getValue1() instanceof BackedModel) {

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -56,8 +56,7 @@ public class InMemoryBackingStore implements BackingStore {
         this.isInitializationCompleted = value;
         for (final Map.Entry<String, Pair<Boolean, Object>> entry : this.store.entrySet()) {
             final Pair<Boolean, Object> wrapper = entry.getValue();
-            Pair<Boolean, Object> updatedValue =
-                    new Pair<>(!value, wrapper.getValue1());
+            Pair<Boolean, Object> updatedValue = new Pair<>(!value, wrapper.getValue1());
 
             if (wrapper.getValue1() instanceof BackedModel) {
                 BackedModel backedModel = (BackedModel) wrapper.getValue1();
@@ -84,9 +83,7 @@ public class InMemoryBackingStore implements BackingStore {
                         != items.length) { // and the size has changed since we last updated
                     updatedValue =
                             new Pair<>(
-                                !value,
-                                new Pair<>(collectionTuple.getValue0(), items.length)
-                            );
+                                    !value, new Pair<>(collectionTuple.getValue0(), items.length));
                 }
             }
             entry.setValue(updatedValue);

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -149,6 +149,9 @@ public class InMemoryBackingStore implements BackingStore {
     @Nullable public <T> T get(@Nonnull final String key) {
         Objects.requireNonNull(key);
         final Pair<Boolean, Object> wrapper = this.store.get(key);
+        if (wrapper == null) {
+            return null;
+        }
         final Object value = this.getValueFromWrapper(wrapper);
 
         boolean hasChanged = wrapper.getValue0();

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -57,7 +57,7 @@ public class InMemoryBackingStore implements BackingStore {
         for (final Map.Entry<String, Pair<Boolean, Object>> entry : this.store.entrySet()) {
             final Pair<Boolean, Object> wrapper = entry.getValue();
             Pair<Boolean, Object> updatedValue =
-                    new Pair<Boolean, Object>(!value, wrapper.getValue1());
+                    new Pair<>(!value, wrapper.getValue1());
 
             if (wrapper.getValue1() instanceof BackedModel) {
                 BackedModel backedModel = (BackedModel) wrapper.getValue1();
@@ -83,8 +83,10 @@ public class InMemoryBackingStore implements BackingStore {
                 if (collectionTuple.getValue1()
                         != items.length) { // and the size has changed since we last updated
                     updatedValue =
-                            new Pair<Boolean, Object>(
-                                    !value, new Pair<>(collectionTuple.getValue0(), items.length));
+                            new Pair<>(
+                                !value,
+                                new Pair<>(collectionTuple.getValue0(), items.length)
+                            );
                 }
             }
             entry.setValue(updatedValue);

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -243,7 +243,7 @@ public class InMemoryBackingStore implements BackingStore {
             if (isCollectionValue(wrapper)) {
                 final Pair<?, Integer> collectionTuple = (Pair<?, Integer>) wrapper.getValue1();
                 Object[] items = getObjectArrayFromCollectionWrapper(collectionTuple);
-                for (Object item : items) {
+                for (final Object item : items) {
                     if (!(item instanceof BackedModel)) break;
                     nestedBackedModelsToEnumerate.add((BackedModel) item);
                 }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /** In-memory implementation of the backing store. Allows for dirty tracking of changes. */
 public class InMemoryBackingStore implements BackingStore {
@@ -48,9 +49,9 @@ public class InMemoryBackingStore implements BackingStore {
 
     private boolean isInitializationCompleted = true;
     private boolean returnOnlyChangedValues;
-    private final Map<String, Pair<Boolean, Object>> store = new HashMap<>();
+    private final Map<String, Pair<Boolean, Object>> store = new ConcurrentHashMap<>();
     private final Map<String, TriConsumer<String, Object, Object>> subscriptionStore =
-            new HashMap<>();
+            new ConcurrentHashMap<>();
 
     public void setIsInitializationCompleted(final boolean value) {
         this.isInitializationCompleted = value;

--- a/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
@@ -1,0 +1,127 @@
+package com.microsoft.kiota;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import com.microsoft.kiota.serialization.AdditionalDataHolder;
+import com.microsoft.kiota.serialization.Parsable;
+import com.microsoft.kiota.serialization.ParseNode;
+import com.microsoft.kiota.serialization.SerializationWriter;
+import com.microsoft.kiota.store.BackedModel;
+import com.microsoft.kiota.store.BackingStore;
+import com.microsoft.kiota.store.BackingStoreFactorySingleton;
+
+public class BaseCollectionPaginationCountResponse implements AdditionalDataHolder, BackedModel, Parsable {
+
+    /**
+     * Stores model information.
+     */
+    @jakarta.annotation.Nonnull
+    protected BackingStore backingStore;
+    /**
+     * Instantiates a new {@link BaseCollectionPaginationCountResponse} and sets the default values.
+     */
+    public BaseCollectionPaginationCountResponse() {
+        this.backingStore = BackingStoreFactorySingleton.instance.createBackingStore();
+        this.setAdditionalData(new HashMap<>());
+    }
+    /**
+     * Creates a new instance of the appropriate class based on discriminator value
+     * @param parseNode The parse node to use to read the discriminator value and create the object
+     * @return a {@link BaseCollectionPaginationCountResponse}
+     */
+    @jakarta.annotation.Nonnull
+    public static BaseCollectionPaginationCountResponse createFromDiscriminatorValue(@jakarta.annotation.Nonnull final ParseNode parseNode) {
+        Objects.requireNonNull(parseNode);
+        return new BaseCollectionPaginationCountResponse();
+    }
+    /**
+     * Gets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+     * @return a {@link Map<String, Object>}
+     */
+    @jakarta.annotation.Nonnull
+    public Map<String, Object> getAdditionalData() {
+        Map<String, Object> value = this.backingStore.get("additionalData");
+        if(value == null) {
+            value = new HashMap<>();
+            this.setAdditionalData(value);
+        }
+        return value;
+    }
+    /**
+     * Gets the backingStore property value. Stores model information.
+     * @return a {@link BackingStore}
+     */
+    @jakarta.annotation.Nonnull
+    public BackingStore getBackingStore() {
+        return this.backingStore;
+    }
+    /**
+     * The deserialization information for the current model
+     * @return a {@link Map<String, java.util.function.Consumer<ParseNode>>}
+     */
+    @jakarta.annotation.Nonnull
+    public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
+        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap = new HashMap<String, java.util.function.Consumer<ParseNode>>(2);
+        deserializerMap.put("@odata.count", (n) -> { this.setOdataCount(n.getLongValue()); });
+        deserializerMap.put("@odata.nextLink", (n) -> { this.setOdataNextLink(n.getStringValue()); });
+        return deserializerMap;
+    }
+    /**
+     * Gets the @odata.count property value. The OdataCount property
+     * @return a {@link Long}
+     */
+    @jakarta.annotation.Nullable
+    public Long getOdataCount() {
+        return this.backingStore.get("odataCount");
+    }
+    /**
+     * Gets the @odata.nextLink property value. The OdataNextLink property
+     * @return a {@link String}
+     */
+    @jakarta.annotation.Nullable
+    public String getOdataNextLink() {
+        return this.backingStore.get("odataNextLink");
+    }
+    /**
+     * Serializes information the current object
+     * @param writer Serialization writer to use to serialize this model
+     */
+    public void serialize(@jakarta.annotation.Nonnull final SerializationWriter writer) {
+        Objects.requireNonNull(writer);
+        writer.writeLongValue("@odata.count", this.getOdataCount());
+        writer.writeStringValue("@odata.nextLink", this.getOdataNextLink());
+        writer.writeAdditionalData(this.getAdditionalData());
+    }
+    /**
+     * Sets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+     * @param value Value to set for the AdditionalData property.
+     */
+    public void setAdditionalData(@jakarta.annotation.Nullable final Map<String, Object> value) {
+        this.backingStore.set("additionalData", value);
+    }
+    /**
+     * Sets the backingStore property value. Stores model information.
+     * @param value Value to set for the backingStore property.
+     */
+    public void setBackingStore(@jakarta.annotation.Nonnull final BackingStore value) {
+        Objects.requireNonNull(value);
+        this.backingStore = value;
+    }
+    /**
+     * Sets the @odata.count property value. The OdataCount property
+     * @param value Value to set for the @odata.count property.
+     */
+    public void setOdataCount(@jakarta.annotation.Nullable final Long value) {
+        this.backingStore.set("odataCount", value);
+    }
+    /**
+     * Sets the @odata.nextLink property value. The OdataNextLink property
+     * @param value Value to set for the @odata.nextLink property.
+     */
+    public void setOdataNextLink(@jakarta.annotation.Nullable final String value) {
+        this.backingStore.set("odataNextLink", value);
+    }
+
+}

--- a/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
@@ -1,9 +1,5 @@
 package com.microsoft.kiota;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
 import com.microsoft.kiota.serialization.AdditionalDataHolder;
 import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.ParseNode;
@@ -12,13 +8,18 @@ import com.microsoft.kiota.store.BackedModel;
 import com.microsoft.kiota.store.BackingStore;
 import com.microsoft.kiota.store.BackingStoreFactorySingleton;
 
-public class BaseCollectionPaginationCountResponse implements AdditionalDataHolder, BackedModel, Parsable {
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class BaseCollectionPaginationCountResponse
+        implements AdditionalDataHolder, BackedModel, Parsable {
 
     /**
      * Stores model information.
      */
-    @jakarta.annotation.Nonnull
-    protected BackingStore backingStore;
+    @jakarta.annotation.Nonnull protected BackingStore backingStore;
+
     /**
      * Instantiates a new {@link BaseCollectionPaginationCountResponse} and sets the default values.
      */
@@ -26,64 +27,75 @@ public class BaseCollectionPaginationCountResponse implements AdditionalDataHold
         this.backingStore = BackingStoreFactorySingleton.instance.createBackingStore();
         this.setAdditionalData(new HashMap<>());
     }
+
     /**
      * Creates a new instance of the appropriate class based on discriminator value
      * @param parseNode The parse node to use to read the discriminator value and create the object
      * @return a {@link BaseCollectionPaginationCountResponse}
      */
-    @jakarta.annotation.Nonnull
-    public static BaseCollectionPaginationCountResponse createFromDiscriminatorValue(@jakarta.annotation.Nonnull final ParseNode parseNode) {
+    @jakarta.annotation.Nonnull public static BaseCollectionPaginationCountResponse createFromDiscriminatorValue(
+            @jakarta.annotation.Nonnull final ParseNode parseNode) {
         Objects.requireNonNull(parseNode);
         return new BaseCollectionPaginationCountResponse();
     }
+
     /**
      * Gets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
      * @return a {@link Map<String, Object>}
      */
-    @jakarta.annotation.Nonnull
-    public Map<String, Object> getAdditionalData() {
+    @jakarta.annotation.Nonnull public Map<String, Object> getAdditionalData() {
         Map<String, Object> value = this.backingStore.get("additionalData");
-        if(value == null) {
+        if (value == null) {
             value = new HashMap<>();
             this.setAdditionalData(value);
         }
         return value;
     }
+
     /**
      * Gets the backingStore property value. Stores model information.
      * @return a {@link BackingStore}
      */
-    @jakarta.annotation.Nonnull
-    public BackingStore getBackingStore() {
+    @jakarta.annotation.Nonnull public BackingStore getBackingStore() {
         return this.backingStore;
     }
+
     /**
      * The deserialization information for the current model
      * @return a {@link Map<String, java.util.function.Consumer<ParseNode>>}
      */
-    @jakarta.annotation.Nonnull
-    public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
-        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap = new HashMap<String, java.util.function.Consumer<ParseNode>>(2);
-        deserializerMap.put("@odata.count", (n) -> { this.setOdataCount(n.getLongValue()); });
-        deserializerMap.put("@odata.nextLink", (n) -> { this.setOdataNextLink(n.getStringValue()); });
+    @jakarta.annotation.Nonnull public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
+        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap =
+                new HashMap<String, java.util.function.Consumer<ParseNode>>(2);
+        deserializerMap.put(
+                "@odata.count",
+                (n) -> {
+                    this.setOdataCount(n.getLongValue());
+                });
+        deserializerMap.put(
+                "@odata.nextLink",
+                (n) -> {
+                    this.setOdataNextLink(n.getStringValue());
+                });
         return deserializerMap;
     }
+
     /**
      * Gets the @odata.count property value. The OdataCount property
      * @return a {@link Long}
      */
-    @jakarta.annotation.Nullable
-    public Long getOdataCount() {
+    @jakarta.annotation.Nullable public Long getOdataCount() {
         return this.backingStore.get("odataCount");
     }
+
     /**
      * Gets the @odata.nextLink property value. The OdataNextLink property
      * @return a {@link String}
      */
-    @jakarta.annotation.Nullable
-    public String getOdataNextLink() {
+    @jakarta.annotation.Nullable public String getOdataNextLink() {
         return this.backingStore.get("odataNextLink");
     }
+
     /**
      * Serializes information the current object
      * @param writer Serialization writer to use to serialize this model
@@ -94,6 +106,7 @@ public class BaseCollectionPaginationCountResponse implements AdditionalDataHold
         writer.writeStringValue("@odata.nextLink", this.getOdataNextLink());
         writer.writeAdditionalData(this.getAdditionalData());
     }
+
     /**
      * Sets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
      * @param value Value to set for the AdditionalData property.
@@ -101,6 +114,7 @@ public class BaseCollectionPaginationCountResponse implements AdditionalDataHold
     public void setAdditionalData(@jakarta.annotation.Nullable final Map<String, Object> value) {
         this.backingStore.set("additionalData", value);
     }
+
     /**
      * Sets the backingStore property value. Stores model information.
      * @param value Value to set for the backingStore property.
@@ -109,6 +123,7 @@ public class BaseCollectionPaginationCountResponse implements AdditionalDataHold
         Objects.requireNonNull(value);
         this.backingStore = value;
     }
+
     /**
      * Sets the @odata.count property value. The OdataCount property
      * @param value Value to set for the @odata.count property.
@@ -116,6 +131,7 @@ public class BaseCollectionPaginationCountResponse implements AdditionalDataHold
     public void setOdataCount(@jakarta.annotation.Nullable final Long value) {
         this.backingStore.set("odataCount", value);
     }
+
     /**
      * Sets the @odata.nextLink property value. The OdataNextLink property
      * @param value Value to set for the @odata.nextLink property.
@@ -123,5 +139,4 @@ public class BaseCollectionPaginationCountResponse implements AdditionalDataHold
     public void setOdataNextLink(@jakarta.annotation.Nullable final String value) {
         this.backingStore.set("odataNextLink", value);
     }
-
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
@@ -116,15 +116,6 @@ public class BaseCollectionPaginationCountResponse
     }
 
     /**
-     * Sets the backingStore property value. Stores model information.
-     * @param value Value to set for the backingStore property.
-     */
-    public void setBackingStore(@jakarta.annotation.Nonnull final BackingStore value) {
-        Objects.requireNonNull(value);
-        this.backingStore = value;
-    }
-
-    /**
      * Sets the @odata.count property value. The OdataCount property
      * @param value Value to set for the @odata.count property.
      */

--- a/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/BaseCollectionPaginationCountResponse.java
@@ -69,12 +69,12 @@ public class BaseCollectionPaginationCountResponse
                 new HashMap<String, java.util.function.Consumer<ParseNode>>(2);
         deserializerMap.put(
                 "@odata.count",
-                (n) -> {
+                n -> {
                     this.setOdataCount(n.getLongValue());
                 });
         deserializerMap.put(
                 "@odata.nextLink",
-                (n) -> {
+                n -> {
                     this.setOdataNextLink(n.getStringValue());
                 });
         return deserializerMap;

--- a/components/abstractions/src/test/java/com/microsoft/kiota/TestEntity.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/TestEntity.java
@@ -109,7 +109,8 @@ public class TestEntity implements Parsable, AdditionalDataHolder, BackedModel {
 
     }
 
-    public static TestEntity createFromDiscriminatorValue(@jakarta.annotation.Nonnull final ParseNode parseNode) {
+    public static TestEntity createFromDiscriminatorValue(
+            @jakarta.annotation.Nonnull final ParseNode parseNode) {
         Objects.requireNonNull(parseNode);
         return new TestEntity();
     }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/TestEntity.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/TestEntity.java
@@ -13,6 +13,7 @@ import jakarta.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 public class TestEntity implements Parsable, AdditionalDataHolder, BackedModel {
@@ -106,5 +107,10 @@ public class TestEntity implements Parsable, AdditionalDataHolder, BackedModel {
     public void serialize(@Nonnull SerializationWriter writer) {
         // TODO Auto-generated method stub
 
+    }
+
+    public static TestEntity createFromDiscriminatorValue(@jakarta.annotation.Nonnull final ParseNode parseNode) {
+        Objects.requireNonNull(parseNode);
+        return new TestEntity();
     }
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/TestEntityCollectionResponse.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/TestEntityCollectionResponse.java
@@ -1,0 +1,65 @@
+package com.microsoft.kiota;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+
+import com.microsoft.kiota.serialization.Parsable;
+import com.microsoft.kiota.serialization.ParseNode;
+import com.microsoft.kiota.serialization.SerializationWriter;
+
+public class TestEntityCollectionResponse extends BaseCollectionPaginationCountResponse implements Parsable {
+
+    /**
+     * Instantiates a new {@link TestEntityCollectionResponse} and sets the default values.
+     */
+    public TestEntityCollectionResponse() {
+        super();
+    }
+    /**
+     * Creates a new instance of the appropriate class based on discriminator value
+     * @param parseNode The parse node to use to read the discriminator value and create the object
+     * @return a {@link TestEntityCollectionResponse}
+     */
+    @jakarta.annotation.Nonnull
+    public static TestEntityCollectionResponse createFromDiscriminatorValue(@jakarta.annotation.Nonnull final ParseNode parseNode) {
+        Objects.requireNonNull(parseNode);
+        return new TestEntityCollectionResponse();
+    }
+    /**
+     * The deserialization information for the current model
+     * @return a {@link Map<String, java.util.function.Consumer<ParseNode>>}
+     */
+    @jakarta.annotation.Nonnull
+    public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
+        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap = new HashMap<String, java.util.function.Consumer<ParseNode>>(super.getFieldDeserializers());
+        deserializerMap.put("value", (n) -> { this.setValue(n.getCollectionOfObjectValues(TestEntity::createFromDiscriminatorValue)); });
+        return deserializerMap;
+    }
+    /**
+     * Gets the value property value. The value property
+     * @return a {@link java.util.List<TestEntity>}
+     */
+    @jakarta.annotation.Nullable
+    public java.util.List<TestEntity> getValue() {
+        return this.backingStore.get("value");
+    }
+    /**
+     * Serializes information the current object
+     * @param writer Serialization writer to use to serialize this model
+     */
+    public void serialize(@jakarta.annotation.Nonnull final SerializationWriter writer) {
+        Objects.requireNonNull(writer);
+        super.serialize(writer);
+        writer.writeCollectionOfObjectValues("value", this.getValue());
+    }
+    /**
+     * Sets the value property value. The value property
+     * @param value Value to set for the value property.
+     */
+    public void setValue(@jakarta.annotation.Nullable final java.util.List<TestEntity> value) {
+        this.backingStore.set("value", value);
+    }
+
+}

--- a/components/abstractions/src/test/java/com/microsoft/kiota/TestEntityCollectionResponse.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/TestEntityCollectionResponse.java
@@ -1,15 +1,15 @@
 package com.microsoft.kiota;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
-
 import com.microsoft.kiota.serialization.Parsable;
 import com.microsoft.kiota.serialization.ParseNode;
 import com.microsoft.kiota.serialization.SerializationWriter;
 
-public class TestEntityCollectionResponse extends BaseCollectionPaginationCountResponse implements Parsable {
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class TestEntityCollectionResponse extends BaseCollectionPaginationCountResponse
+        implements Parsable {
 
     /**
      * Instantiates a new {@link TestEntityCollectionResponse} and sets the default values.
@@ -17,34 +17,44 @@ public class TestEntityCollectionResponse extends BaseCollectionPaginationCountR
     public TestEntityCollectionResponse() {
         super();
     }
+
     /**
      * Creates a new instance of the appropriate class based on discriminator value
      * @param parseNode The parse node to use to read the discriminator value and create the object
      * @return a {@link TestEntityCollectionResponse}
      */
-    @jakarta.annotation.Nonnull
-    public static TestEntityCollectionResponse createFromDiscriminatorValue(@jakarta.annotation.Nonnull final ParseNode parseNode) {
+    @jakarta.annotation.Nonnull public static TestEntityCollectionResponse createFromDiscriminatorValue(
+            @jakarta.annotation.Nonnull final ParseNode parseNode) {
         Objects.requireNonNull(parseNode);
         return new TestEntityCollectionResponse();
     }
+
     /**
      * The deserialization information for the current model
      * @return a {@link Map<String, java.util.function.Consumer<ParseNode>>}
      */
-    @jakarta.annotation.Nonnull
-    public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
-        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap = new HashMap<String, java.util.function.Consumer<ParseNode>>(super.getFieldDeserializers());
-        deserializerMap.put("value", (n) -> { this.setValue(n.getCollectionOfObjectValues(TestEntity::createFromDiscriminatorValue)); });
+    @jakarta.annotation.Nonnull public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
+        final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap =
+                new HashMap<String, java.util.function.Consumer<ParseNode>>(
+                        super.getFieldDeserializers());
+        deserializerMap.put(
+                "value",
+                (n) -> {
+                    this.setValue(
+                            n.getCollectionOfObjectValues(
+                                    TestEntity::createFromDiscriminatorValue));
+                });
         return deserializerMap;
     }
+
     /**
      * Gets the value property value. The value property
      * @return a {@link java.util.List<TestEntity>}
      */
-    @jakarta.annotation.Nullable
-    public java.util.List<TestEntity> getValue() {
+    @jakarta.annotation.Nullable public java.util.List<TestEntity> getValue() {
         return this.backingStore.get("value");
     }
+
     /**
      * Serializes information the current object
      * @param writer Serialization writer to use to serialize this model
@@ -54,6 +64,7 @@ public class TestEntityCollectionResponse extends BaseCollectionPaginationCountR
         super.serialize(writer);
         writer.writeCollectionOfObjectValues("value", this.getValue());
     }
+
     /**
      * Sets the value property value. The value property
      * @param value Value to set for the value property.
@@ -61,5 +72,4 @@ public class TestEntityCollectionResponse extends BaseCollectionPaginationCountR
     public void setValue(@jakarta.annotation.Nullable final java.util.List<TestEntity> value) {
         this.backingStore.set("value", value);
     }
-
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/TestEntityCollectionResponse.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/TestEntityCollectionResponse.java
@@ -33,13 +33,14 @@ public class TestEntityCollectionResponse extends BaseCollectionPaginationCountR
      * The deserialization information for the current model
      * @return a {@link Map<String, java.util.function.Consumer<ParseNode>>}
      */
+    @Override
     @jakarta.annotation.Nonnull public Map<String, java.util.function.Consumer<ParseNode>> getFieldDeserializers() {
         final HashMap<String, java.util.function.Consumer<ParseNode>> deserializerMap =
                 new HashMap<String, java.util.function.Consumer<ParseNode>>(
                         super.getFieldDeserializers());
         deserializerMap.put(
                 "value",
-                (n) -> {
+                n -> {
                     this.setValue(
                             n.getCollectionOfObjectValues(
                                     TestEntity::createFromDiscriminatorValue));
@@ -59,6 +60,7 @@ public class TestEntityCollectionResponse extends BaseCollectionPaginationCountR
      * Serializes information the current object
      * @param writer Serialization writer to use to serialize this model
      */
+    @Override
     public void serialize(@jakarta.annotation.Nonnull final SerializationWriter writer) {
         Objects.requireNonNull(writer);
         super.serialize(writer);

--- a/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
@@ -466,22 +466,6 @@ class InMemoryBackingStoreTest {
     }
 
     @Test
-    void testLargeArraysPerformsWell() {
-        // Arrange
-        var testBackingStore = new InMemoryBackingStore();
-        // Act
-        assertTrue(testBackingStore.enumerate().isEmpty());
-        var testArray = new int[100000000];
-        testBackingStore.set("values", testArray);
-        long startTimeMillis = System.currentTimeMillis();
-        testBackingStore.setIsInitializationCompleted(true);
-        long timeTakenMillis = System.currentTimeMillis() - startTimeMillis;
-
-        // Assert
-        assertTrue(timeTakenMillis < 1);
-    }
-
-    @Test
     void testInitializationCompletedIsPropagatedToMapItems() {
         var colleagues = new HashMap<String, Object>();
         for (int i = 0; i < 10; i++) {
@@ -523,7 +507,6 @@ class InMemoryBackingStoreTest {
         for (TestEntity colleague : testUser.getValue()) {
             assertTrue(colleague.getBackingStore().getIsInitializationCompleted());
         }
-
     }
 
     @Test
@@ -555,7 +538,8 @@ class InMemoryBackingStoreTest {
         testUser.getBackingStore().setReturnOnlyChangedValues(false);
         testUser.getColleagues().get(9).getAdditionalData().put("moreRandom", 123);
 
-        // collection consistency should loop through all nested backed models in the collection and find one with a dirty additional data map
+        // collection consistency should loop through all nested backed models in the collection and
+        // find one with a dirty additional data map
         testUser.getBackingStore().setReturnOnlyChangedValues(true);
         assertNotNull(testUser.getColleagues());
         var changedValues = testUser.getBackingStore().enumerate();
@@ -563,7 +547,8 @@ class InMemoryBackingStoreTest {
     }
 
     @Test
-    void testCollectionPropertyConsistencyChecksEnumeratesNestedBackedModelsInAllNestedCollections() {
+    void
+            testCollectionPropertyConsistencyChecksEnumeratesNestedBackedModelsInAllNestedCollections() {
         var colleagues = new ArrayList<TestEntity>();
         for (int i = 0; i < 10; i++) {
             var colleague = new TestEntity();
@@ -589,9 +574,12 @@ class InMemoryBackingStoreTest {
 
         // Update nested backed model
         testUser.getBackingStore().setReturnOnlyChangedValues(false);
-        ((TestEntity) testUser.getColleagues().get(9).getAdditionalData().get("manager")).getAdditionalData().put("moreRandom", 123);
+        ((TestEntity) testUser.getColleagues().get(9).getAdditionalData().get("manager"))
+                .getAdditionalData()
+                .put("moreRandom", 123);
 
-        // collection consistency should loop through all nested backed models in the collection and find one with a dirty additional data map
+        // collection consistency should loop through all nested backed models in the collection and
+        // find one with a dirty additional data map
         testUser.getBackingStore().setReturnOnlyChangedValues(true);
         var changedValues = testUser.getBackingStore().enumerate();
         assertNotNull(testUser.getColleagues());

--- a/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
@@ -439,15 +439,19 @@ class InMemoryBackingStoreTest {
 
         var testUserCollectionResponse = new TestEntityCollectionResponse();
         testUserCollectionResponse.setValue(colleagues);
+        // After set(), while adding nested subscriptions, all values in the collection now have
+        // initializationCompleted=false & their properties are all dirty
         testUserCollectionResponse.getBackingStore().setIsInitializationCompleted(true);
 
         // Act on the data by making a change
         var manager = new TestEntity();
         manager.setId("2fe22fe5-1132-42cf-90f9-1dc17e325a74");
         manager.getBackingStore().setIsInitializationCompleted(true);
-        testUserCollectionResponse.getValue().get(0).setManager(manager);
+        var collectionValues = testUserCollectionResponse.getValue();
+        collectionValues.get(0).setManager(manager);
 
         // Assert by retrieving only changed values
+        testUserCollectionResponse.getBackingStore().setReturnOnlyChangedValues(true);
         var changedValues = testUserCollectionResponse.getBackingStore().enumerate();
         assertEquals(1, changedValues.size());
         assertEquals("value", changedValues.keySet().toArray()[0]);

--- a/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
@@ -452,6 +452,10 @@ class InMemoryBackingStoreTest {
         assertEquals(1, changedValues.size());
         assertEquals("value", changedValues.keySet().toArray()[0]);
         assertEquals(10, ((List<?>) changedValues.values().toArray()[0]).size());
-        assertTrue(((TestEntity)((List<?>)changedValues.values().toArray()[0]).get(0)).getBackingStore().enumerate().containsKey("manager"));
+        assertTrue(
+                ((TestEntity) ((List<?>) changedValues.values().toArray()[0]).get(0))
+                        .getBackingStore()
+                        .enumerate()
+                        .containsKey("manager"));
     }
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/store/InMemoryBackingStoreTest.java
@@ -462,4 +462,20 @@ class InMemoryBackingStoreTest {
                         .enumerate()
                         .containsKey("manager"));
     }
+
+    @Test
+    void testLargeArraysPerformsWell() {
+        // Arrange
+        var testBackingStore = new InMemoryBackingStore();
+        // Act
+        assertTrue(testBackingStore.enumerate().isEmpty());
+        var testArray = new int[100000000];
+        testBackingStore.set("values", testArray);
+        long startTimeMillis = System.currentTimeMillis();
+        testBackingStore.setIsInitializationCompleted(true);
+        long timeTakenMillis = System.currentTimeMillis() - startTimeMillis;
+
+        // Assert
+        assertTrue(timeTakenMillis < 1);
+    }
 }

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/options/UserAgentHandlerOption.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/middleware/options/UserAgentHandlerOption.java
@@ -13,7 +13,7 @@ public class UserAgentHandlerOption implements RequestOption {
 
     private boolean enabled = true;
     @Nonnull private String productName = "kiota-java";
-    @Nonnull private String productVersion = "1.3.0";
+    @Nonnull private String productVersion = "1.4.0";
 
     /**
      * Gets the product name to be used in the user agent header

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ org.gradle.caching=true
 
 mavenGroupId         = com.microsoft.kiota
 mavenMajorVersion = 1
-mavenMinorVersion = 3
+mavenMinorVersion = 4
 mavenPatchVersion = 0
 mavenArtifactSuffix =
 


### PR DESCRIPTION
Fixes a bug encountered while marking all properties in an `InMemoryBackingStore` as dirty.

### Context

When iterating over a `Map` [`entrySet()`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Map.html#entrySet()), any modification to the underlying map causes undefined behavior during the iteration.

The `InMemoryBackingStore` iterates over the underlying store's [`entrySet()`](https://github.com/microsoft/kiota-java/blob/main/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java#L57) and currently calls [`ensureCollectionPropertyIsConsistent()`](https://github.com/microsoft/kiota-java/blob/main/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java#L65C13-L65C49) which may update the underlying Map by calling [`set()`](https://github.com/microsoft/kiota-java/blob/main/components/abstractions/src/main/java/com/microsoft/kiota/store/InMemoryBackingStore.java#L231) to update the collection size & flag the collection as dirty in case of additions/deletions. 


Undefined behaviour manifests as repeated iterations over the same set of items in the underlying store causing performance issues. The situation is amplified when we have a collection of `BackedModel`s where each `BackedModel` has a collection property that has been updated and we need to mark all properties of all the `BackedModel`s as dirty. 

### Changes

This PR:
- Updates check for collection size consistency to prevent updating the underlying map during iteration.
- Reduces redundant recursive calls when cascading dirty tracking to nested `BackedModel` elements
- Separates concerns by allowing `get()` to determine whether a value is dirty or not which matches its interface [definition](https://github.com/microsoft/kiota-java/blob/main/components/abstractions/src/main/java/com/microsoft/kiota/store/BackingStore.java#L15). `getValueFromWrapper()` now only unwraps values from the underlying store
- Fixes bug to ensure collection properties are checked for consistency before determining if they are dirty when we want to return only changed values

The sample test case would previously fail after running for `~60s` vs with this fix, it passes in `~3s` on the same hardware.

closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/2106