### PR TITLE
Release packages sequentially with info logs to debug failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
     - name: Publish Release abstractions
       run: |
         componentTaskPath=$(echo ${{ matrix.component-path }} | tr / :)
-        ./gradlew --no-daemon :components:$componentTaskPath:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
+        ./gradlew -i --no-daemon :components:$componentTaskPath:$PUBLISH_TASK -PmavenCentralSnapshotArtifactSuffix=""
 
   release-to-github:
     if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
       run:
         working-directory: ./
     strategy:
+      max-parallel: 1
       matrix:
         component-path: [
           abstractions,


### PR DESCRIPTION
Automated publishing from staging to Maven central is currently flaky with:
- GH workflow failures yet the packages are deployed to Maven Central
- staging repos left open but publishing to Maven Central has succeeded.
- etc
e.g. https://github.com/microsoft/kiota-java/actions/runs/10829253429

This should give us more insight into what's happening.