### PR TITLE
Allow backing store serialization configuration in serialization helpers

### DIFF
--- a/components/abstractions/android/build.gradle
+++ b/components/abstractions/android/build.gradle
@@ -57,6 +57,7 @@ android {
         disable "GradleDependency"
         disable "NewerVersionAvailable"
         disable "DuplicatePlatformClasses"      // xpp3 added by azure-identity
+        disable "LambdaLast"                    // Wrongly enforced in KiotaJsonSerialization helpers
     }
     sourceSets {
         main {

--- a/components/abstractions/gradle/dependencies.gradle
+++ b/components/abstractions/gradle/dependencies.gradle
@@ -3,6 +3,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.1'
     testImplementation 'org.mockito:mockito-core:5.14.1'
+    testImplementation project(':components:serialization:json')
 
     // Use JUnit Jupiter Engine for testing.
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'

--- a/components/abstractions/spotBugsExcludeFilter.xml
+++ b/components/abstractions/spotBugsExcludeFilter.xml
@@ -47,12 +47,10 @@ xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubu
 		<Class name="com.microsoft.kiota.serialization.SerializationHelpersTest" />
 	</Match>
     <Match>
-		<Bug pattern="EI_EXPOSE_REP" />
-		<Class name="com.microsoft.kiota.serialization.mocks.TestEntity" />
-	</Match>
-    <Match>
         <Bug pattern="EI_EXPOSE_REP" />
         <Or>
+            <Class name="com.microsoft.kiota.serialization.mocks.TestEntity" />
+            <Class name="com.microsoft.kiota.serialization.mocks.TestBackedModelEntity" />
             <Class name="com.microsoft.kiota.TestEntity" />
             <Class name="com.microsoft.kiota.BaseCollectionPaginationCountResponse" />
         </Or>

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
@@ -35,9 +35,9 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
-            final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
+            @Nonnull final T value, final boolean serializeOnlyChangedValues) throws IOException {
         return KiotaSerialization.serializeAsStream(
-                CONTENT_TYPE, serializeOnlyChangedValues, value);
+                CONTENT_TYPE, value, serializeOnlyChangedValues);
     }
 
     /**
@@ -61,9 +61,9 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
-            final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
+            @Nonnull final T value, final boolean serializeOnlyChangedValues) throws IOException {
         return KiotaSerialization.serializeAsString(
-                CONTENT_TYPE, serializeOnlyChangedValues, value);
+                CONTENT_TYPE, value, serializeOnlyChangedValues);
     }
 
     /**
@@ -87,10 +87,10 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
-            final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
+            @Nonnull final Iterable<T> values, final boolean serializeOnlyChangedValues)
             throws IOException {
         return KiotaSerialization.serializeAsStream(
-                CONTENT_TYPE, serializeOnlyChangedValues, values);
+                CONTENT_TYPE, values, serializeOnlyChangedValues);
     }
 
     /**
@@ -114,10 +114,10 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
-            final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
+            @Nonnull final Iterable<T> values, final boolean serializeOnlyChangedValues)
             throws IOException {
         return KiotaSerialization.serializeAsString(
-                CONTENT_TYPE, serializeOnlyChangedValues, values);
+                CONTENT_TYPE, values, serializeOnlyChangedValues);
     }
 
     /**

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
@@ -27,6 +27,20 @@ public class KiotaJsonSerialization {
     }
 
     /**
+     * Serializes the given value to a stream
+     * @param <T> the type of the value to serialize
+     * @param value the value to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a stream
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
+            @Nonnull final T value, final boolean serializeOnlyChangedValues) throws IOException {
+        return KiotaSerialization.serializeAsStream(
+                CONTENT_TYPE, value, serializeOnlyChangedValues);
+    }
+
+    /**
      * Serializes the given value to a string
      * @param <T> the type of the value to serialize
      * @param value the value to serialize
@@ -36,6 +50,20 @@ public class KiotaJsonSerialization {
     @Nonnull public static <T extends Parsable> String serializeAsString(@Nonnull final T value)
             throws IOException {
         return KiotaSerialization.serializeAsString(CONTENT_TYPE, value);
+    }
+
+    /**
+     * Serializes the given value to a string
+     * @param <T> the type of the value to serialize
+     * @param value the value to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a string
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> String serializeAsString(
+            @Nonnull final T value, final boolean serializeOnlyChangedValues) throws IOException {
+        return KiotaSerialization.serializeAsString(
+                CONTENT_TYPE, value, serializeOnlyChangedValues);
     }
 
     /**
@@ -51,6 +79,21 @@ public class KiotaJsonSerialization {
     }
 
     /**
+     * Serializes the given value to a stream
+     * @param <T> the type of the value to serialize
+     * @param values the values to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a stream
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
+            @Nonnull final Iterable<T> values, final boolean serializeOnlyChangedValues)
+            throws IOException {
+        return KiotaSerialization.serializeAsStream(
+                CONTENT_TYPE, values, serializeOnlyChangedValues);
+    }
+
+    /**
      * Serializes the given value to a string
      * @param <T> the type of the value to serialize
      * @param values the values to serialize
@@ -60,6 +103,21 @@ public class KiotaJsonSerialization {
     @Nonnull public static <T extends Parsable> String serializeAsString(@Nonnull final Iterable<T> values)
             throws IOException {
         return KiotaSerialization.serializeAsString(CONTENT_TYPE, values);
+    }
+
+    /**
+     * Serializes the given value to a string
+     * @param <T> the type of the value to serialize
+     * @param values the values to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a string
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> String serializeAsString(
+            @Nonnull final Iterable<T> values, final boolean serializeOnlyChangedValues)
+            throws IOException {
+        return KiotaSerialization.serializeAsString(
+                CONTENT_TYPE, values, serializeOnlyChangedValues);
     }
 
     /**

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
@@ -35,9 +35,9 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
-            @Nonnull final T value, final boolean serializeOnlyChangedValues) throws IOException {
+        final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
         return KiotaSerialization.serializeAsStream(
-                CONTENT_TYPE, value, serializeOnlyChangedValues);
+                CONTENT_TYPE, serializeOnlyChangedValues, value);
     }
 
     /**
@@ -61,9 +61,9 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
-            @Nonnull final T value, final boolean serializeOnlyChangedValues) throws IOException {
+        final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
         return KiotaSerialization.serializeAsString(
-                CONTENT_TYPE, value, serializeOnlyChangedValues);
+                CONTENT_TYPE, serializeOnlyChangedValues, value);
     }
 
     /**
@@ -87,10 +87,10 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
-            @Nonnull final Iterable<T> values, final boolean serializeOnlyChangedValues)
+        final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
             throws IOException {
         return KiotaSerialization.serializeAsStream(
-                CONTENT_TYPE, values, serializeOnlyChangedValues);
+                CONTENT_TYPE, serializeOnlyChangedValues, values);
     }
 
     /**
@@ -114,10 +114,10 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
-            @Nonnull final Iterable<T> values, final boolean serializeOnlyChangedValues)
+        final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
             throws IOException {
         return KiotaSerialization.serializeAsString(
-                CONTENT_TYPE, values, serializeOnlyChangedValues);
+                CONTENT_TYPE, serializeOnlyChangedValues, values);
     }
 
     /**

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaJsonSerialization.java
@@ -35,7 +35,7 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
-        final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
+            final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
         return KiotaSerialization.serializeAsStream(
                 CONTENT_TYPE, serializeOnlyChangedValues, value);
     }
@@ -61,7 +61,7 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
-        final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
+            final boolean serializeOnlyChangedValues, @Nonnull final T value) throws IOException {
         return KiotaSerialization.serializeAsString(
                 CONTENT_TYPE, serializeOnlyChangedValues, value);
     }
@@ -87,7 +87,7 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
-        final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
+            final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
             throws IOException {
         return KiotaSerialization.serializeAsStream(
                 CONTENT_TYPE, serializeOnlyChangedValues, values);
@@ -114,7 +114,7 @@ public class KiotaJsonSerialization {
      * @throws IOException when the stream cannot be closed or read.
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
-        final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
+            final boolean serializeOnlyChangedValues, @Nonnull final Iterable<T> values)
             throws IOException {
         return KiotaSerialization.serializeAsString(
                 CONTENT_TYPE, serializeOnlyChangedValues, values);

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaSerialization.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaSerialization.java
@@ -30,7 +30,7 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType, @Nonnull final T value) throws IOException {
-        return serializeAsStream(contentType, value, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+        return serializeAsStream(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, value);
     }
 
     /**
@@ -44,8 +44,8 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType,
-            @Nonnull final T value,
-            final boolean serializeOnlyChangedValues)
+            final boolean serializeOnlyChangedValues,
+            @Nonnull final T value)
             throws IOException {
         Objects.requireNonNull(value);
         try (final SerializationWriter writer =
@@ -66,7 +66,7 @@ public final class KiotaSerialization {
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType, @Nonnull final T value) throws IOException {
         Objects.requireNonNull(value);
-        return serializeAsString(contentType, value, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+        return serializeAsString(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, value);
     }
 
     /**
@@ -80,12 +80,12 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType,
-            @Nonnull final T value,
-            final boolean serializeOnlyChangedValues)
+            final boolean serializeOnlyChangedValues,
+            @Nonnull final T value)
             throws IOException {
         Objects.requireNonNull(value);
         try (final InputStream stream =
-                serializeAsStream(contentType, value, serializeOnlyChangedValues)) {
+                serializeAsStream(contentType, serializeOnlyChangedValues, value)) {
             return new String(Compatibility.readAllBytes(stream), CHARSET_NAME);
         }
     }
@@ -102,7 +102,7 @@ public final class KiotaSerialization {
             @Nonnull final String contentType, @Nonnull final Iterable<T> values)
             throws IOException {
         Objects.requireNonNull(values);
-        return serializeAsStream(contentType, values, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+        return serializeAsStream(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, values);
     }
 
     /**
@@ -116,8 +116,8 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType,
-            @Nonnull final Iterable<T> values,
-            final boolean serializeOnlyChangedValues)
+            final boolean serializeOnlyChangedValues,
+            @Nonnull final Iterable<T> values)
             throws IOException {
         Objects.requireNonNull(values);
         try (final SerializationWriter writer =
@@ -139,7 +139,7 @@ public final class KiotaSerialization {
             @Nonnull final String contentType, @Nonnull final Iterable<T> values)
             throws IOException {
         Objects.requireNonNull(values);
-        return serializeAsString(contentType, values, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+        return serializeAsString(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, values);
     }
 
     /**
@@ -153,12 +153,12 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType,
-            @Nonnull final Iterable<T> values,
-            final boolean serializeOnlyChangedValues)
+            final boolean serializeOnlyChangedValues,
+            @Nonnull final Iterable<T> values)
             throws IOException {
         Objects.requireNonNull(values);
         try (final InputStream stream =
-                serializeAsStream(contentType, values, serializeOnlyChangedValues)) {
+                serializeAsStream(contentType, serializeOnlyChangedValues, values)) {
             return new String(Compatibility.readAllBytes(stream), CHARSET_NAME);
         }
     }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaSerialization.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaSerialization.java
@@ -16,6 +16,7 @@ import java.util.Objects;
  */
 public final class KiotaSerialization {
     private static final String CHARSET_NAME = "UTF-8";
+    private static final boolean DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES = true;
 
     private KiotaSerialization() {}
 
@@ -29,7 +30,26 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType, @Nonnull final T value) throws IOException {
-        try (final SerializationWriter writer = getSerializationWriter(contentType, value)) {
+        return serializeAsStream(contentType, value, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+    }
+
+    /**
+     * Serializes the given value to a stream and configures returned values by the backing store if available
+     * @param <T> the type of the value to serialize
+     * @param contentType the content type to use for serialization
+     * @param value the value to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a stream
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
+            @Nonnull final String contentType,
+            @Nonnull final T value,
+            final boolean serializeOnlyChangedValues)
+            throws IOException {
+        Objects.requireNonNull(value);
+        try (final SerializationWriter writer =
+                getSerializationWriter(contentType, serializeOnlyChangedValues)) {
             writer.writeObjectValue("", value);
             return writer.getSerializedContent();
         }
@@ -45,7 +65,27 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType, @Nonnull final T value) throws IOException {
-        try (final InputStream stream = serializeAsStream(contentType, value)) {
+        Objects.requireNonNull(value);
+        return serializeAsString(contentType, value, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+    }
+
+    /**
+     * Serializes the given value to a string
+     * @param <T> the type of the value to serialize
+     * @param contentType the content type to use for serialization
+     * @param value the value to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a string
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> String serializeAsString(
+            @Nonnull final String contentType,
+            @Nonnull final T value,
+            final boolean serializeOnlyChangedValues)
+            throws IOException {
+        Objects.requireNonNull(value);
+        try (final InputStream stream =
+                serializeAsStream(contentType, value, serializeOnlyChangedValues)) {
             return new String(Compatibility.readAllBytes(stream), CHARSET_NAME);
         }
     }
@@ -61,7 +101,27 @@ public final class KiotaSerialization {
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType, @Nonnull final Iterable<T> values)
             throws IOException {
-        try (final SerializationWriter writer = getSerializationWriter(contentType, values)) {
+        Objects.requireNonNull(values);
+        return serializeAsStream(contentType, values, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+    }
+
+    /**
+     * Serializes the given value to a stream
+     * @param <T> the type of the value to serialize
+     * @param contentType the content type to use for serialization
+     * @param values the values to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a stream
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
+            @Nonnull final String contentType,
+            @Nonnull final Iterable<T> values,
+            final boolean serializeOnlyChangedValues)
+            throws IOException {
+        Objects.requireNonNull(values);
+        try (final SerializationWriter writer =
+                getSerializationWriter(contentType, serializeOnlyChangedValues)) {
             writer.writeCollectionOfObjectValues("", values);
             return writer.getSerializedContent();
         }
@@ -78,20 +138,39 @@ public final class KiotaSerialization {
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType, @Nonnull final Iterable<T> values)
             throws IOException {
-        try (final InputStream stream = serializeAsStream(contentType, values)) {
+        Objects.requireNonNull(values);
+        return serializeAsString(contentType, values, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
+    }
+
+    /**
+     * Serializes the given value to a string
+     * @param <T> the type of the value to serialize
+     * @param contentType the content type to use for serialization
+     * @param values the values to serialize
+     * @param serializeOnlyChangedValues whether to serialize all values in value if value is a BackedModel
+     * @return the serialized value as a string
+     * @throws IOException when the stream cannot be closed or read.
+     */
+    @Nonnull public static <T extends Parsable> String serializeAsString(
+            @Nonnull final String contentType,
+            @Nonnull final Iterable<T> values,
+            final boolean serializeOnlyChangedValues)
+            throws IOException {
+        Objects.requireNonNull(values);
+        try (final InputStream stream =
+                serializeAsStream(contentType, values, serializeOnlyChangedValues)) {
             return new String(Compatibility.readAllBytes(stream), CHARSET_NAME);
         }
     }
 
     private static SerializationWriter getSerializationWriter(
-            @Nonnull final String contentType, @Nonnull final Object value) {
+            @Nonnull final String contentType, final boolean serializeOnlyChangedValues) {
         Objects.requireNonNull(contentType);
-        Objects.requireNonNull(value);
         if (contentType.isEmpty()) {
             throw new NullPointerException("content type cannot be empty");
         }
         return SerializationWriterFactoryRegistry.defaultInstance.getSerializationWriter(
-                contentType);
+                contentType, serializeOnlyChangedValues);
     }
 
     /**

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaSerialization.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/KiotaSerialization.java
@@ -30,7 +30,7 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType, @Nonnull final T value) throws IOException {
-        return serializeAsStream(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, value);
+        return serializeAsStream(contentType, value, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
     }
 
     /**
@@ -44,8 +44,8 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType,
-            final boolean serializeOnlyChangedValues,
-            @Nonnull final T value)
+            @Nonnull final T value,
+            final boolean serializeOnlyChangedValues)
             throws IOException {
         Objects.requireNonNull(value);
         try (final SerializationWriter writer =
@@ -66,7 +66,7 @@ public final class KiotaSerialization {
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType, @Nonnull final T value) throws IOException {
         Objects.requireNonNull(value);
-        return serializeAsString(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, value);
+        return serializeAsString(contentType, value, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
     }
 
     /**
@@ -80,12 +80,12 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType,
-            final boolean serializeOnlyChangedValues,
-            @Nonnull final T value)
+            @Nonnull final T value,
+            final boolean serializeOnlyChangedValues)
             throws IOException {
         Objects.requireNonNull(value);
         try (final InputStream stream =
-                serializeAsStream(contentType, serializeOnlyChangedValues, value)) {
+                serializeAsStream(contentType, value, serializeOnlyChangedValues)) {
             return new String(Compatibility.readAllBytes(stream), CHARSET_NAME);
         }
     }
@@ -102,7 +102,7 @@ public final class KiotaSerialization {
             @Nonnull final String contentType, @Nonnull final Iterable<T> values)
             throws IOException {
         Objects.requireNonNull(values);
-        return serializeAsStream(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, values);
+        return serializeAsStream(contentType, values, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
     }
 
     /**
@@ -116,8 +116,8 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> InputStream serializeAsStream(
             @Nonnull final String contentType,
-            final boolean serializeOnlyChangedValues,
-            @Nonnull final Iterable<T> values)
+            @Nonnull final Iterable<T> values,
+            final boolean serializeOnlyChangedValues)
             throws IOException {
         Objects.requireNonNull(values);
         try (final SerializationWriter writer =
@@ -139,7 +139,7 @@ public final class KiotaSerialization {
             @Nonnull final String contentType, @Nonnull final Iterable<T> values)
             throws IOException {
         Objects.requireNonNull(values);
-        return serializeAsString(contentType, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES, values);
+        return serializeAsString(contentType, values, DEFAULT_SERIALIZE_ONLY_CHANGED_VALUES);
     }
 
     /**
@@ -153,12 +153,12 @@ public final class KiotaSerialization {
      */
     @Nonnull public static <T extends Parsable> String serializeAsString(
             @Nonnull final String contentType,
-            final boolean serializeOnlyChangedValues,
-            @Nonnull final Iterable<T> values)
+            @Nonnull final Iterable<T> values,
+            final boolean serializeOnlyChangedValues)
             throws IOException {
         Objects.requireNonNull(values);
         try (final InputStream stream =
-                serializeAsStream(contentType, serializeOnlyChangedValues, values)) {
+                serializeAsStream(contentType, values, serializeOnlyChangedValues)) {
             return new String(Compatibility.readAllBytes(stream), CHARSET_NAME);
         }
     }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactoryRegistry.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactoryRegistry.java
@@ -118,8 +118,8 @@ public class SerializationWriterFactoryRegistry implements SerializationWriterFa
      * Wrapper class to carry the cleaned version of content-type after parsing in multiple stages
      */
     private static final class ContentTypeWrapper {
-        private String contentType;
-        private String cleanedContentType;
+        String contentType;
+        String cleanedContentType;
 
         ContentTypeWrapper(@Nonnull final String contentType) {
             this.contentType = contentType;

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactoryRegistry.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterFactoryRegistry.java
@@ -81,7 +81,7 @@ public class SerializationWriterFactoryRegistry implements SerializationWriterFa
             return contentTypeAssociatedFactories.get(contentTypeWrapper.cleanedContentType);
         }
         final String cleanedContentType =
-                getCleanedVendorSpecificContentType(contentTypeWrapper.cleanedContentType);
+                getCleanedVendorSpecificContentType(vendorSpecificContentType);
         if (contentTypeAssociatedFactories.containsKey(cleanedContentType)) {
             contentTypeWrapper.cleanedContentType = cleanedContentType;
             return contentTypeAssociatedFactories.get(contentTypeWrapper.cleanedContentType);

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterProxyFactory.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterProxyFactory.java
@@ -13,7 +13,7 @@ public abstract class SerializationWriterProxyFactory implements SerializationWr
         return _concrete.getValidContentType();
     }
 
-    private final SerializationWriterFactory _concrete;
+    protected final SerializationWriterFactory _concrete;
     private final Consumer<Parsable> _onBefore;
     private final Consumer<Parsable> _onAfter;
     private final BiConsumer<Parsable, SerializationWriter> _onStart;

--- a/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterProxyFactory.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/serialization/SerializationWriterProxyFactory.java
@@ -10,10 +10,10 @@ import java.util.function.Consumer;
 /** Proxy factory that allows the composition of before and after callbacks on existing factories. */
 public abstract class SerializationWriterProxyFactory implements SerializationWriterFactory {
     @Nonnull public String getValidContentType() {
-        return _concrete.getValidContentType();
+        return proxiedFactory.getValidContentType();
     }
 
-    protected final SerializationWriterFactory _concrete;
+    protected final SerializationWriterFactory proxiedFactory;
     private final Consumer<Parsable> _onBefore;
     private final Consumer<Parsable> _onAfter;
     private final BiConsumer<Parsable, SerializationWriter> _onStart;
@@ -30,14 +30,14 @@ public abstract class SerializationWriterProxyFactory implements SerializationWr
             @Nullable final Consumer<Parsable> onBeforeSerialization,
             @Nullable final Consumer<Parsable> onAfterSerialization,
             @Nullable final BiConsumer<Parsable, SerializationWriter> onStartObjectSerialization) {
-        _concrete = Objects.requireNonNull(concrete);
+        proxiedFactory = Objects.requireNonNull(concrete);
         _onBefore = onBeforeSerialization;
         _onAfter = onAfterSerialization;
         _onStart = onStartObjectSerialization;
     }
 
     @Nonnull public SerializationWriter getSerializationWriter(@Nonnull final String contentType) {
-        final SerializationWriter writer = _concrete.getSerializationWriter(contentType);
+        final SerializationWriter writer = proxiedFactory.getSerializationWriter(contentType);
         final Consumer<Parsable> originalBefore = writer.getOnBeforeObjectSerialization();
         final Consumer<Parsable> originalAfter = writer.getOnAfterObjectSerialization();
         final BiConsumer<Parsable, SerializationWriter> originalStart =

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
@@ -62,7 +62,7 @@ public class BackingStoreSerializationWriterProxyFactory extends SerializationWr
     @Nonnull public SerializationWriter getSerializationWriter(
             @Nonnull final String contentType, final boolean serializeOnlyChangedValues) {
         if (!serializeOnlyChangedValues) {
-            return _concrete.getSerializationWriter(contentType);
+            return proxiedFactory.getSerializationWriter(contentType);
         }
         return getSerializationWriter(contentType);
     }

--- a/components/abstractions/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/store/BackingStoreSerializationWriterProxyFactory.java
@@ -1,5 +1,6 @@
 package com.microsoft.kiota.store;
 
+import com.microsoft.kiota.serialization.SerializationWriter;
 import com.microsoft.kiota.serialization.SerializationWriterFactory;
 import com.microsoft.kiota.serialization.SerializationWriterProxyFactory;
 
@@ -47,5 +48,22 @@ public class BackingStoreSerializationWriterProxyFactory extends SerializationWr
                         }
                     }
                 });
+    }
+
+    /**
+     * Returns a SerializationWriter that overrides the default serialization of only changed values if serializeOnlyChangedValues="true"
+     * Gets the previously proxied serialization writer without any backing store configuration to prevent overwriting the registry affecting
+     * future serialization requests
+     *
+     * @param contentType HTTP content type header value
+     * @param serializeOnlyChangedValues alter backing store default behavior
+     * @return the SerializationWriter
+     */
+    @Nonnull public SerializationWriter getSerializationWriter(
+            @Nonnull final String contentType, final boolean serializeOnlyChangedValues) {
+        if (!serializeOnlyChangedValues) {
+            return _concrete.getSerializationWriter(contentType);
+        }
+        return getSerializationWriter(contentType);
     }
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
@@ -112,14 +112,14 @@ class SerializationHelpersTest {
         // Sets the backing store to be initialized. No properties are dirty
         entity.getBackingStore().setIsInitializationCompleted(true);
 
-        final String result = KiotaJsonSerialization.serializeAsString(false, entity);
+        final String result = KiotaJsonSerialization.serializeAsString(entity, false);
 
         assertFalse(entity.getBackingStore().getReturnOnlyChangedValues());
         assertEquals("{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}", result);
 
         final String collectionResult =
                 KiotaJsonSerialization.serializeAsString(
-                        false, new ArrayList<>(Arrays.asList(entity)));
+                        new ArrayList<>(Arrays.asList(entity)), false);
 
         assertEquals("[{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}]", collectionResult);
     }
@@ -138,14 +138,14 @@ class SerializationHelpersTest {
         entity.setOfficeLocation("Nairobi");
         entity.getBackingStore().setIsInitializationCompleted(true);
 
-        final String result = KiotaJsonSerialization.serializeAsString(true, entity);
+        final String result = KiotaJsonSerialization.serializeAsString(entity, true);
 
         assertFalse(entity.getBackingStore().getReturnOnlyChangedValues());
         assertEquals("{}", result);
 
         final String collectionResult =
                 KiotaJsonSerialization.serializeAsString(
-                        true, new ArrayList<>(Arrays.asList(entity)));
+                        new ArrayList<>(Arrays.asList(entity)), true);
         assertEquals("[{}]", collectionResult);
     }
 

--- a/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
@@ -1,6 +1,7 @@
 package com.microsoft.kiota.serialization;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -9,13 +10,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.microsoft.kiota.serialization.mocks.TestBackedModelEntity;
 import com.microsoft.kiota.serialization.mocks.TestEntity;
+import com.microsoft.kiota.store.BackingStoreSerializationWriterProxyFactory;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 class SerializationHelpersTest {
     private static final String _jsonContentType = "application/json";
@@ -90,5 +94,58 @@ class SerializationHelpersTest {
                         });
         assertEquals("[{'id':'123'}]", result);
         verify(mockSerializationWriter, times(1)).writeCollectionOfObjectValues(eq(""), any());
+    }
+
+    @Test
+    void serializesAllValuesInBackedModel() throws IOException {
+        final BackingStoreSerializationWriterProxyFactory
+                backingStoreSerializationWriterProxyFactory =
+                        new BackingStoreSerializationWriterProxyFactory(
+                                new JsonSerializationWriterFactory());
+        SerializationWriterFactoryRegistry.defaultInstance.contentTypeAssociatedFactories.put(
+                _jsonContentType, backingStoreSerializationWriterProxyFactory);
+
+        final TestBackedModelEntity entity = new TestBackedModelEntity();
+        entity.setId("123");
+        entity.setOfficeLocation("Nairobi");
+
+        entity.getBackingStore().setIsInitializationCompleted(true);
+
+        final String result = KiotaJsonSerialization.serializeAsString(entity, false);
+
+        assertFalse(entity.getBackingStore().getReturnOnlyChangedValues());
+        assertEquals("{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}", result);
+
+        final String collectionResult =
+                KiotaJsonSerialization.serializeAsString(
+                        new ArrayList<>(Arrays.asList(entity)), false);
+
+        assertEquals("[{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}]", collectionResult);
+    }
+
+    @Test
+    void serializesChangedValuesInBackedModel() throws IOException {
+        final BackingStoreSerializationWriterProxyFactory
+                backingStoreSerializationWriterProxyFactory =
+                        new BackingStoreSerializationWriterProxyFactory(
+                                new JsonSerializationWriterFactory());
+        SerializationWriterFactoryRegistry.defaultInstance.contentTypeAssociatedFactories.put(
+                _jsonContentType, backingStoreSerializationWriterProxyFactory);
+
+        final TestBackedModelEntity entity = new TestBackedModelEntity();
+        entity.setId("123");
+        entity.setOfficeLocation("Nairobi");
+
+        entity.getBackingStore().setIsInitializationCompleted(true);
+
+        final String result = KiotaJsonSerialization.serializeAsString(entity, true);
+
+        assertFalse(entity.getBackingStore().getReturnOnlyChangedValues());
+        assertEquals("{}", result);
+
+        final String collectionResult =
+                KiotaJsonSerialization.serializeAsString(
+                        new ArrayList<>(Arrays.asList(entity)), true);
+        assertEquals("[{}]", collectionResult);
     }
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
@@ -111,14 +111,15 @@ class SerializationHelpersTest {
 
         entity.getBackingStore().setIsInitializationCompleted(true);
 
-        final String result = KiotaJsonSerialization.serializeAsString(entity, false);
+        final String result = KiotaJsonSerialization.serializeAsString(false, entity);
 
         assertFalse(entity.getBackingStore().getReturnOnlyChangedValues());
         assertEquals("{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}", result);
 
         final String collectionResult =
                 KiotaJsonSerialization.serializeAsString(
-                        new ArrayList<>(Arrays.asList(entity)), false);
+                        false,
+                        new ArrayList<>(Arrays.asList(entity)));
 
         assertEquals("[{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}]", collectionResult);
     }
@@ -138,14 +139,15 @@ class SerializationHelpersTest {
 
         entity.getBackingStore().setIsInitializationCompleted(true);
 
-        final String result = KiotaJsonSerialization.serializeAsString(entity, true);
+        final String result = KiotaJsonSerialization.serializeAsString(true, entity);
 
         assertFalse(entity.getBackingStore().getReturnOnlyChangedValues());
         assertEquals("{}", result);
 
         final String collectionResult =
                 KiotaJsonSerialization.serializeAsString(
-                        new ArrayList<>(Arrays.asList(entity)), true);
+                        true,
+                        new ArrayList<>(Arrays.asList(entity)));
         assertEquals("[{}]", collectionResult);
     }
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/serialization/SerializationHelpersTest.java
@@ -119,8 +119,7 @@ class SerializationHelpersTest {
 
         final String collectionResult =
                 KiotaJsonSerialization.serializeAsString(
-                        false,
-                        new ArrayList<>(Arrays.asList(entity)));
+                        false, new ArrayList<>(Arrays.asList(entity)));
 
         assertEquals("[{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}]", collectionResult);
     }
@@ -146,8 +145,7 @@ class SerializationHelpersTest {
 
         final String collectionResult =
                 KiotaJsonSerialization.serializeAsString(
-                        true,
-                        new ArrayList<>(Arrays.asList(entity)));
+                        true, new ArrayList<>(Arrays.asList(entity)));
         assertEquals("[{}]", collectionResult);
     }
 
@@ -164,12 +162,16 @@ class SerializationHelpersTest {
         entity.setId("123");
         entity.setOfficeLocation("Nairobi");
 
-        final String result = KiotaSerialization.serializeAsString("application/json;odata.metadata=minimal", entity);
+        final String result =
+                KiotaSerialization.serializeAsString(
+                        "application/json;odata.metadata=minimal", entity);
         assertEquals("{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}", result);
 
-        // Because onAfterObjectSerialization, returnOnlyChangedValues is set to false & initialization is completed
+        // Because onAfterObjectSerialization, returnOnlyChangedValues is set to false &
+        // initialization is completed
         entity.getBackingStore().setIsInitializationCompleted(false);
-        final String otherResult = KiotaSerialization.serializeAsString("application/vnd.github.raw+json", entity);
+        final String otherResult =
+                KiotaSerialization.serializeAsString("application/vnd.github.raw+json", entity);
         assertEquals("{\"id\":\"123\",\"officeLocation\":\"Nairobi\"}", otherResult);
     }
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/serialization/mocks/TestBackedModelEntity.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/serialization/mocks/TestBackedModelEntity.java
@@ -30,16 +30,16 @@ public class TestBackedModelEntity implements Parsable, AdditionalDataHolder, Ba
         return this.backingStore.get("id");
     }
 
-    public void setId(String _id) {
-        this.backingStore.set("id", _id);
+    public void setId(String id) {
+        this.backingStore.set("id", id);
     }
 
     public String getOfficeLocation() {
         return this.backingStore.get("officeLocation");
     }
 
-    public void setOfficeLocation(String _officeLocation) {
-        this.backingStore.set("officeLocation", _officeLocation);
+    public void setOfficeLocation(String officeLocation) {
+        this.backingStore.set("officeLocation", officeLocation);
     }
 
     public LocalDate getBirthDay() {
@@ -88,37 +88,37 @@ public class TestBackedModelEntity implements Parsable, AdditionalDataHolder, Ba
             {
                 put(
                         "id",
-                        (n) -> {
+                        n -> {
                             setId(n.getStringValue());
                         });
                 put(
                         "officeLocation",
-                        (n) -> {
+                        n -> {
                             setOfficeLocation(n.getStringValue());
                         });
                 put(
                         "birthDay",
-                        (n) -> {
+                        n -> {
                             setBirthDay(n.getLocalDateValue());
                         });
                 put(
                         "workDuration",
-                        (n) -> {
+                        n -> {
                             setWorkDuration(n.getPeriodAndDurationValue());
                         });
                 put(
                         "startWorkTime",
-                        (n) -> {
+                        n -> {
                             setStartWorkTime(n.getLocalTimeValue());
                         });
                 put(
                         "endWorkTime",
-                        (n) -> {
+                        n -> {
                             setEndWorkTime(n.getLocalTimeValue());
                         });
                 put(
                         "createdDateTime",
-                        (n) -> {
+                        n -> {
                             setCreatedDateTime(n.getOffsetDateTimeValue());
                         });
             }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/serialization/mocks/TestBackedModelEntity.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/serialization/mocks/TestBackedModelEntity.java
@@ -1,0 +1,168 @@
+package com.microsoft.kiota.serialization.mocks;
+
+import com.microsoft.kiota.PeriodAndDuration;
+import com.microsoft.kiota.serialization.AdditionalDataHolder;
+import com.microsoft.kiota.serialization.Parsable;
+import com.microsoft.kiota.serialization.ParseNode;
+import com.microsoft.kiota.serialization.SerializationWriter;
+import com.microsoft.kiota.store.BackedModel;
+import com.microsoft.kiota.store.BackingStore;
+import com.microsoft.kiota.store.BackingStoreFactorySingleton;
+
+import jakarta.annotation.Nonnull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public class TestBackedModelEntity implements Parsable, AdditionalDataHolder, BackedModel {
+    private BackingStore backingStore;
+
+    public TestBackedModelEntity() {
+        backingStore = BackingStoreFactorySingleton.instance.createBackingStore();
+    }
+
+    public String getId() {
+        return this.backingStore.get("id");
+    }
+
+    public void setId(String _id) {
+        this.backingStore.set("id", _id);
+    }
+
+    public String getOfficeLocation() {
+        return this.backingStore.get("officeLocation");
+    }
+
+    public void setOfficeLocation(String _officeLocation) {
+        this.backingStore.set("officeLocation", _officeLocation);
+    }
+
+    public LocalDate getBirthDay() {
+        return this.backingStore.get("birthDay");
+    }
+
+    public void setBirthDay(LocalDate value) {
+        this.backingStore.set("birthDay", value);
+    }
+
+    public PeriodAndDuration getWorkDuration() {
+        return this.backingStore.get("workDuration");
+    }
+
+    public void setWorkDuration(PeriodAndDuration value) {
+        this.backingStore.set("workDuration", PeriodAndDuration.ofPeriodAndDuration(value));
+    }
+
+    public LocalTime getStartWorkTime() {
+        return this.backingStore.get("startWorkTime");
+    }
+
+    public void setStartWorkTime(LocalTime value) {
+        this.backingStore.set("startWorkTime", value);
+    }
+
+    public LocalTime getEndWorkTime() {
+        return this.backingStore.get("endWorkTime");
+    }
+
+    public void setEndWorkTime(LocalTime value) {
+        this.backingStore.set("endWorkTime", value);
+    }
+
+    public OffsetDateTime getCreatedDateTime() {
+        return this.backingStore.get("createdDateTime");
+    }
+
+    public void setCreatedDateTime(OffsetDateTime value) {
+        this.backingStore.set("createdDateTime", value);
+    }
+
+    @Nonnull @Override
+    public Map<String, Consumer<ParseNode>> getFieldDeserializers() {
+        return new HashMap<>() {
+            {
+                put(
+                        "id",
+                        (n) -> {
+                            setId(n.getStringValue());
+                        });
+                put(
+                        "officeLocation",
+                        (n) -> {
+                            setOfficeLocation(n.getStringValue());
+                        });
+                put(
+                        "birthDay",
+                        (n) -> {
+                            setBirthDay(n.getLocalDateValue());
+                        });
+                put(
+                        "workDuration",
+                        (n) -> {
+                            setWorkDuration(n.getPeriodAndDurationValue());
+                        });
+                put(
+                        "startWorkTime",
+                        (n) -> {
+                            setStartWorkTime(n.getLocalTimeValue());
+                        });
+                put(
+                        "endWorkTime",
+                        (n) -> {
+                            setEndWorkTime(n.getLocalTimeValue());
+                        });
+                put(
+                        "createdDateTime",
+                        (n) -> {
+                            setCreatedDateTime(n.getOffsetDateTimeValue());
+                        });
+            }
+        };
+    }
+
+    @Override
+    public void serialize(@Nonnull SerializationWriter writer) {
+        Objects.requireNonNull(writer);
+        writer.writeStringValue("id", getId());
+        writer.writeStringValue("officeLocation", getOfficeLocation());
+        writer.writeLocalDateValue("birthDay", getBirthDay());
+        writer.writePeriodAndDurationValue("workDuration", getWorkDuration());
+        writer.writeLocalTimeValue("startWorkTime", getStartWorkTime());
+        writer.writeLocalTimeValue("endWorkTime", getEndWorkTime());
+        writer.writeOffsetDateTimeValue("createdDateTime", getCreatedDateTime());
+        writer.writeAdditionalData(getAdditionalData());
+    }
+
+    @Nonnull @Override
+    public Map<String, Object> getAdditionalData() {
+        Map<String, Object> value = this.backingStore.get("additionalData");
+        if (value == null) {
+            value = new HashMap<>();
+            this.setAdditionalData(value);
+        }
+        return value;
+    }
+
+    /**
+     * Sets the AdditionalData property value. Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
+     * @param value Value to set for the AdditionalData property.
+     */
+    public void setAdditionalData(@jakarta.annotation.Nullable final Map<String, Object> value) {
+        this.backingStore.set("additionalData", value);
+    }
+
+    @jakarta.annotation.Nonnull public static TestEntity createFromDiscriminatorValue(
+            @jakarta.annotation.Nonnull final ParseNode parseNode) {
+        return new TestEntity();
+    }
+
+    @Override
+    public BackingStore getBackingStore() {
+        return backingStore;
+    }
+}


### PR DESCRIPTION
closes https://github.com/microsoft/kiota-java/issues/1131

Allows overriding default backing store behaviour while serializing.
- Retains previous serialization helper method implementation with the default behaviour of returning only changed values (`true`). To prevent backward incompatibility.

### Usage
Before:
```java
// BackedModel model = kiotaClient...get();
String result = KiotaJsonSerialization.serializeAsString(model); // returns empty string since no property has changed.
```
Now:

```java
// User model = kiotaClient...get();
String result = KiotaJsonSerialization.serializeAsString(model, false); // returns serialized string by disabling returnOnlyChangedValues
```