### PR TITLE
Support overriding default interceptor options 

### DIFF
--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/KiotaClientFactory.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/KiotaClientFactory.java
@@ -185,7 +185,7 @@ public class KiotaClientFactory {
      * @deprecated Use {@link #createDefaultInterceptors()} instead.
      */
     @Deprecated
-    @Nonnull private static List<Interceptor> createDefaultInterceptorsAsList() {
+    @Nonnull public static List<Interceptor> createDefaultInterceptorsAsList() {
         return new ArrayList<>(Arrays.asList(createDefaultInterceptors()));
     }
 }

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/KiotaClientFactory.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/KiotaClientFactory.java
@@ -87,8 +87,20 @@ public class KiotaClientFactory {
      */
     @Nonnull public static OkHttpClient.Builder create(
             @Nonnull final BaseBearerTokenAuthenticationProvider authenticationProvider) {
+        return create(authenticationProvider, new RequestOption[0]);
+    }
+
+    /**
+     * Creates an OkHttpClient Builder with the Authorization handler and optional custom default middleware configurations
+     * @param authenticationProvider authentication provider to use for the AuthorizationHandler.
+     * @param requestOptions The request options to use for the interceptors.
+     * @return an OkHttpClient Builder instance.
+     */
+    @Nonnull public static OkHttpClient.Builder create(
+            @Nonnull final BaseBearerTokenAuthenticationProvider authenticationProvider,
+            @Nonnull final RequestOption[] requestOptions) {
         ArrayList<Interceptor> interceptors =
-                new ArrayList<>(Arrays.asList(createDefaultInterceptors()));
+                new ArrayList<>(Arrays.asList(createDefaultInterceptors(requestOptions)));
         interceptors.add(new AuthorizationHandler(authenticationProvider));
         return create(interceptors);
     }
@@ -173,7 +185,7 @@ public class KiotaClientFactory {
      * @deprecated Use {@link #createDefaultInterceptors()} instead.
      */
     @Deprecated
-    @Nonnull public static List<Interceptor> createDefaultInterceptorsAsList() {
+    @Nonnull private static List<Interceptor> createDefaultInterceptorsAsList() {
         return new ArrayList<>(Arrays.asList(createDefaultInterceptors()));
     }
 }


### PR DESCRIPTION
Adds missing method overload to support customizing default interceptors with options.

part of https://github.com/microsoftgraph/msgraph-sdk-java-core/issues/1757