### PR TITLE
Handle exceptions when resetting streams after writing to the network

### DIFF
--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -902,10 +902,8 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
 
                                 @Override
                                 public void writeTo(@Nonnull BufferedSink sink) throws IOException {
-                                    // stored in variable before writing to the sink due to
-                                    // available()'s definition
                                     long contentLength = contentLength();
-                                    if (contentLength() > 0) {
+                                    if (contentLength > 0) {
                                         requestInfo.content.mark((int) contentLength);
                                     }
                                     sink.writeAll(Okio.source(requestInfo.content));

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -904,7 +904,15 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                                 public void writeTo(@Nonnull BufferedSink sink) throws IOException {
                                     sink.writeAll(Okio.source(requestInfo.content));
                                     if (!isOneShot()) {
-                                        requestInfo.content.reset();
+                                        try {
+                                            requestInfo.content.reset();
+                                        } catch (Exception ex) {
+                                            spanForAttributes.recordException(ex);
+                                            // we don't want to fail the request if reset() fails
+                                            // reset() was a measure to prevent draining the request
+                                            // body by an interceptor before
+                                            // the final network request
+                                        }
                                     }
                                 }
                             };

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -902,9 +902,15 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
 
                                 @Override
                                 public void writeTo(@Nonnull BufferedSink sink) throws IOException {
+                                    // stored in variable before writing to the sink due to
+                                    // available()'s definition
+                                    long contentLength = contentLength();
                                     sink.writeAll(Okio.source(requestInfo.content));
                                     if (!isOneShot()) {
                                         try {
+                                            if (contentLength > 0) {
+                                                requestInfo.content.mark((int) contentLength);
+                                            }
                                             requestInfo.content.reset();
                                         } catch (Exception ex) {
                                             spanForAttributes.recordException(ex);

--- a/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
+++ b/components/http/okHttp/src/main/java/com/microsoft/kiota/http/OkHttpRequestAdapter.java
@@ -905,12 +905,12 @@ public class OkHttpRequestAdapter implements com.microsoft.kiota.RequestAdapter 
                                     // stored in variable before writing to the sink due to
                                     // available()'s definition
                                     long contentLength = contentLength();
+                                    if (contentLength() > 0) {
+                                        requestInfo.content.mark((int) contentLength);
+                                    }
                                     sink.writeAll(Okio.source(requestInfo.content));
                                     if (!isOneShot()) {
                                         try {
-                                            if (contentLength > 0) {
-                                                requestInfo.content.mark((int) contentLength);
-                                            }
                                             requestInfo.content.reset();
                                         } catch (Exception ex) {
                                             spanForAttributes.recordException(ex);


### PR DESCRIPTION
We added the `isOneShot()` check to ensure that rewindable request body streams are reset after writing them e.g. after request body is written to a logging interceptor. Previously, a logging interceptor would drain the request body stream causing the network call to have an empty body.

However, we didn't handle the failure scenarios of `reset()` according to the [docs](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#reset--)

This PR makes a best effort measure to prevent draining the request body by an interceptor before the final network request.

If a positive content length is available, we [`mark()`](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#mark-int-) the start of the stream with the entire stream's content length as the read limit.

If during the `sink.writeAll()` a new `mark()` is set causing the `reset()` to fail, we log the exception but don't fail the entire request.

We do not fail the entire request in case the first call to `reset()` happens during the network call.

closes https://github.com/microsoftgraph/msgraph-sdk-java/issues/2245

Existing unit [tests](https://github.com/microsoft/kiota-java/blob/main/components/http/okHttp/src/test/java/com/microsoft/kiota/http/OkHttpRequestAdapterTest.java#L410-L536) for the various stream scenarios still pass