### PR TITLE
chore: use gradle version catalogs as a single source of truth for dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "java-library"
-    id "org.sonarqube" version "6.2.0.5505"
-    id 'com.github.spotbugs' version '6.2.1'
-    id "com.diffplug.spotless" version "7.0.4"
+    alias(libs.plugins.org.sonarqube)
+    alias(libs.plugins.com.github.spotbugs)
+    alias(libs.plugins.com.diffplug.spotless)
 }
 
 sonar {

--- a/components/abstractions/android/build.gradle
+++ b/components/abstractions/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/abstractions/gradle/dependencies.gradle
+++ b/components/abstractions/gradle/dependencies.gradle
@@ -1,12 +1,12 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation 'org.mockito:mockito-core:5.18.0'
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
+    testImplementation(libs.org.mockito.mockito.core)
     testImplementation project(':components:serialization:json')
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'io.github.std-uritemplate:std-uritemplate:2.0.0'
-    implementation 'io.opentelemetry:opentelemetry-api:1.51.0'
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    implementation(libs.io.github.std.uritemplate.std.uritemplate)
+    implementation(libs.io.opentelemetry.opentelemetry.api)
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
 }

--- a/components/authentication/azure/android/build.gradle
+++ b/components/authentication/azure/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/authentication/azure/gradle/dependencies.gradle
+++ b/components/authentication/azure/gradle/dependencies.gradle
@@ -1,15 +1,15 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation 'org.mockito:mockito-core:5.18.0'
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
+    testImplementation(libs.org.mockito.mockito.core)
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'io.opentelemetry:opentelemetry-api:1.51.0'
-    implementation 'io.opentelemetry:opentelemetry-context:1.51.0'
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
-    api 'javax.xml.stream:stax-api:1.0-2'
-    api 'com.azure:azure-core:1.55.5'
+    implementation(libs.io.opentelemetry.opentelemetry.api)
+    implementation(libs.io.opentelemetry.opentelemetry.context)
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
+    api(libs.javax.xml.stream.stax.api)
+    api(libs.com.azure.azure.core)
 
     api project(':components:abstractions')
 }

--- a/components/bundle/android/build.gradle
+++ b/components/bundle/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/bundle/gradle/dependencies.gradle
+++ b/components/bundle/gradle/dependencies.gradle
@@ -1,11 +1,11 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
 
-    testImplementation 'org.mockito:mockito-core:5.18.0'
+    testImplementation(libs.org.mockito.mockito.core)
 
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
 
     api project(':components:abstractions')
     api project(':components:http:okHttp')

--- a/components/http/okHttp/android/build.gradle
+++ b/components/http/okHttp/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/http/okHttp/gradle/dependencies.gradle
+++ b/components/http/okHttp/gradle/dependencies.gradle
@@ -1,18 +1,18 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
 
-    testImplementation 'org.mockito:mockito-core:5.18.0'
-    testImplementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation(libs.org.mockito.mockito.core)
+    testImplementation(libs.com.squareup.okhttp3.logging.interceptor)
+    testImplementation(libs.com.squareup.okhttp3.mockwebserver)
 
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'io.opentelemetry:opentelemetry-api:1.51.0'
-    implementation 'io.opentelemetry:opentelemetry-context:1.51.0'
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
-    api 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation(libs.io.opentelemetry.opentelemetry.api)
+    implementation(libs.io.opentelemetry.opentelemetry.context)
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
+    api(libs.com.squareup.okhttp3.okhttp)
 
     api project(':components:abstractions')
 }

--- a/components/serialization/form/android/build.gradle
+++ b/components/serialization/form/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/serialization/form/gradle/dependencies.gradle
+++ b/components/serialization/form/gradle/dependencies.gradle
@@ -1,10 +1,10 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
 
     api project(':components:abstractions')
 }

--- a/components/serialization/json/android/build.gradle
+++ b/components/serialization/json/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/serialization/json/gradle/dependencies.gradle
+++ b/components/serialization/json/gradle/dependencies.gradle
@@ -1,11 +1,11 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
-    api 'com.google.code.gson:gson:2.13.1'
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
+    api(libs.com.google.code.gson.gson)
 
     api project(':components:abstractions')
 }

--- a/components/serialization/multipart/android/build.gradle
+++ b/components/serialization/multipart/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/serialization/multipart/gradle/dependencies.gradle
+++ b/components/serialization/multipart/gradle/dependencies.gradle
@@ -1,11 +1,11 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    testImplementation 'org.mockito:mockito-core:5.18.0'
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
+    testImplementation(libs.org.mockito.mockito.core)
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
 
     api project(':components:abstractions')
     testImplementation project(':components:serialization:json')

--- a/components/serialization/text/android/build.gradle
+++ b/components/serialization/text/android/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.gradle:gradle-enterprise-gradle-plugin:3.19.2"
-        classpath "com.android.tools.build:gradle:8.11.0"
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.52.0"
+        classpath(libs.com.gradle.gradle.enterprise.gradle.plugin)
+        classpath(libs.com.android.tools.build.gradle)
+        classpath(libs.com.github.ben.manes.gradle.versions.plugin)
     }
 }
 

--- a/components/serialization/text/gradle/dependencies.gradle
+++ b/components/serialization/text/gradle/dependencies.gradle
@@ -1,10 +1,10 @@
 dependencies {
     // Use JUnit Jupiter API for testing.
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.org.junit.jupiter.junit.jupiter)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
 
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
-    implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    implementation(libs.jakarta.annotation.jakarta.annotation.api)
 
     api project(':components:abstractions')
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,22 @@
+[versions]
+okhttp = "4.12.0"
+opentelemetry = "1.51.0"
+
 [libraries]
 com-android-tools-build-gradle = { group = "com.android.tools.build", name = "gradle", version = "8.11.0" }
 com-azure-azure-core = { group = "com.azure", name = "azure-core", version = "1.55.5" }
 com-github-ben-manes-gradle-versions-plugin = { group = "com.github.ben-manes", name = "gradle-versions-plugin", version = "0.52.0" }
 com-google-code-gson-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.1" }
 com-gradle-gradle-enterprise-gradle-plugin = { group = "com.gradle", name = "gradle-enterprise-gradle-plugin", version = "3.19.2" }
-com-squareup-okhttp3-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version = "4.12.0" }
-com-squareup-okhttp3-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version = "4.12.0" }
-com-squareup-okhttp3-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0" }
+com-squareup-okhttp3-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
+com-squareup-okhttp3-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
+com-squareup-okhttp3-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 io-github-std-uritemplate-std-uritemplate = { group = "io.github.std-uritemplate", name = "std-uritemplate", version = "2.0.0" }
-io-opentelemetry-opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api", version = "1.51.0" }
-io-opentelemetry-opentelemetry-context = { group = "io.opentelemetry", name = "opentelemetry-context", version = "1.51.0" }
+io-opentelemetry-opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api", version.ref = "opentelemetry" }
+io-opentelemetry-opentelemetry-context = { group = "io.opentelemetry", name = "opentelemetry-context", version.ref = "opentelemetry" }
 jakarta-annotation-jakarta-annotation-api = { group = "jakarta.annotation", name = "jakarta.annotation-api", version = "2.1.1" }
 javax-xml-stream-stax-api = { group = "javax.xml.stream", name = "stax-api", version = "1.0-2" }
-org-junit-jupiter-junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version = "5.13.2" }
+org-junit-jupiter-junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version = "5.13.3" }
 org-junit-platform-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version = "1.13.0-M3" }
 org-mockito-mockito-core = { group = "org.mockito", name = "mockito-core", version = "5.18.0" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,6 @@ org-junit-platform-junit-platform-launcher = { group = "org.junit.platform", nam
 org-mockito-mockito-core = { group = "org.mockito", name = "mockito-core", version = "5.18.0" }
 
 [plugins]
-com-diffplug-spotless = { id = "com.diffplug.spotless", version = "7.0.4" }
+com-diffplug-spotless = { id = "com.diffplug.spotless", version = "7.1.0" }
 com-github-spotbugs = { id = "com.github.spotbugs", version = "6.2.1" }
 org-sonarqube = { id = "org.sonarqube", version = "6.2.0.5505" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,22 @@
+[libraries]
+com-android-tools-build-gradle = { group = "com.android.tools.build", name = "gradle", version = "8.11.0" }
+com-azure-azure-core = { group = "com.azure", name = "azure-core", version = "1.55.5" }
+com-github-ben-manes-gradle-versions-plugin = { group = "com.github.ben-manes", name = "gradle-versions-plugin", version = "0.52.0" }
+com-google-code-gson-gson = { group = "com.google.code.gson", name = "gson", version = "2.13.1" }
+com-gradle-gradle-enterprise-gradle-plugin = { group = "com.gradle", name = "gradle-enterprise-gradle-plugin", version = "3.19.2" }
+com-squareup-okhttp3-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version = "4.12.0" }
+com-squareup-okhttp3-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version = "4.12.0" }
+com-squareup-okhttp3-okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0" }
+io-github-std-uritemplate-std-uritemplate = { group = "io.github.std-uritemplate", name = "std-uritemplate", version = "2.0.0" }
+io-opentelemetry-opentelemetry-api = { group = "io.opentelemetry", name = "opentelemetry-api", version = "1.51.0" }
+io-opentelemetry-opentelemetry-context = { group = "io.opentelemetry", name = "opentelemetry-context", version = "1.51.0" }
+jakarta-annotation-jakarta-annotation-api = { group = "jakarta.annotation", name = "jakarta.annotation-api", version = "2.1.1" }
+javax-xml-stream-stax-api = { group = "javax.xml.stream", name = "stax-api", version = "1.0-2" }
+org-junit-jupiter-junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version = "5.13.2" }
+org-junit-platform-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version = "1.13.0-M3" }
+org-mockito-mockito-core = { group = "org.mockito", name = "mockito-core", version = "5.18.0" }
+
+[plugins]
+com-diffplug-spotless = { id = "com.diffplug.spotless", version = "7.0.4" }
+com-github-spotbugs = { id = "com.github.spotbugs", version = "6.2.1" }
+org-sonarqube = { id = "org.sonarqube", version = "6.2.0.5505" }


### PR DESCRIPTION
Closes #1594 

Move all definition of dependencies into [Gradle version catalogs](https://docs.gradle.org/current/userguide/version_catalogs.html).
This will reduce duplicates of same dependency update in multiple sub projects such as:
<img width="893" alt="image" src="https://github.com/user-attachments/assets/2143b3a6-86ee-4e0e-b10d-d287901dfd28" />


Mostly auto-generated by [the tool I wrote](https://github.com/exoego/gradle-version-catalogs-cli)