### PR TITLE
Fix deserialization of `List<Double>` in JSON parse node

### DIFF
--- a/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
+++ b/components/serialization/json/src/main/java/com/microsoft/kiota/serialization/JsonParseNode.java
@@ -146,6 +146,8 @@ public class JsonParseNode implements ParseNode {
             return (T) itemNode.getIntegerValue();
         } else if (targetClass == Float.class) {
             return (T) itemNode.getFloatValue();
+        } else if (targetClass == Double.class) {
+            return (T) itemNode.getDoubleValue();
         } else if (targetClass == Long.class) {
             return (T) itemNode.getLongValue();
         } else if (targetClass == UUID.class) {

--- a/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
+++ b/components/serialization/json/src/test/java/com/microsoft/kiota/serialization/JsonParseNodeTests.java
@@ -172,4 +172,19 @@ class JsonParseNodeTests {
             }
         }
     }
+
+    @Test
+    void getCollectionOfPrimitiveDoubleValues() throws UnsupportedEncodingException {
+        final var initialString = "{\"values\":[1.1,2.2,3.3]}";
+        final var rawResponse = new ByteArrayInputStream(initialString.getBytes("UTF-8"));
+        final var parseNode = _parseNodeFactory.getParseNode(contentType, rawResponse);
+        final var valuesNode = parseNode.getChildNode("values");
+        assertNotNull(valuesNode);
+        final var doubles = valuesNode.getCollectionOfPrimitiveValues(Double.class);
+        assertNotNull(doubles);
+        assertEquals(3, doubles.size());
+        assertEquals(1.1, doubles.get(0), 0.000001);
+        assertEquals(2.2, doubles.get(1), 0.000001);
+        assertEquals(3.3, doubles.get(2), 0.000001);
+    }
 }


### PR DESCRIPTION
## Fix deserialization of `List<Double>` in JSON parse node

### Summary
Adds support for `java.lang.Double` in JSON primitive value parsing, fixing failures when deserializing collections of doubles. Includes a unit test validating getCollectionOfPrimitiveValues(Double.class).

### Motivation
Collections of Double values could not be deserialized because JsonParseNode.getPrimitiveValue lacked a `Double.class` branch. This broke scenarios parsing arrays like [1.1, 2.2, 3.3], including on kiota-generated model classes that contain lists of doubles.


### Changes

- Adds handling for `Double.class` in `getPrimitiveValue` by delegating to `getDoubleValue()` in `JsonParseNodeTests`
- Adds getCollectionOfPrimitiveDoubleValues test asserting successful parsing of {"values":[1.1,2.2,3.3]} into a List<Double>.  Prior to the update in getPrimitiveValue, this test failed with `java.lang.RuntimeException: unknown type to deserialize java.lang.Double`
