### PR TITLE
ci: fixes dependabot path for devcontainer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
       patterns:
         - "*opentelemetry*"
 - package-ecosystem: devcontainers
-  directory: "/.devcontainer"
+  directory: "/"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
follow up to #2124 to address the issues seen in https://github.com/microsoft/kiota-java/actions/runs/27289516766/job/80605946984