### PR TITLE
Route Gradle dependency resolution through the CFS central package feed

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -72,21 +72,34 @@ extends:
                   Copy-Item $(downloadLocalProperties.secureFilePath) local.properties -Verbose
                 displayName: Copy secring and 'local.properties'
 
-              - script: ./gradlew --no-daemon publishToMavenLocal -PmavenCentralPublishingEnabled=true -PmavenCentralSnapshotArtifactSuffix=""
+              - task: MavenAuthenticate@0
+                displayName: Authenticate to Azure Artifacts feed (PAT-less)
+                inputs:
+                  artifactsFeeds: 'GraphDeveloperExperiences_Public'
+
+              - script: ./gradlew --no-daemon --init-script .azure-pipelines/network-isolation-feed.init.gradle publishToMavenLocal -PmavenCentralPublishingEnabled=true -PmavenCentralSnapshotArtifactSuffix=""
                 displayName: Publish to local Maven for verification
                 condition: contains(variables['build.sourceBranch'], 'refs/tags/v')
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-              - script: ./gradlew --no-daemon publishToMavenLocal -PmavenCentralPublishingEnabled=true
+              - script: ./gradlew --no-daemon --init-script .azure-pipelines/network-isolation-feed.init.gradle publishToMavenLocal -PmavenCentralPublishingEnabled=true
                 displayName: Publish to local Maven for verification
                 condition: not(contains(variables['build.sourceBranch'], 'refs/tags/v'))
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-              - script: ./gradlew --no-daemon publishMavenPublicationToADORepository -PmavenCentralPublishingEnabled=true -PmavenCentralSnapshotArtifactSuffix=""
+              - script: ./gradlew --no-daemon --init-script .azure-pipelines/network-isolation-feed.init.gradle publishMavenPublicationToADORepository -PmavenCentralPublishingEnabled=true -PmavenCentralSnapshotArtifactSuffix=""
                 displayName: Publish to local Maven ADO for ESRP
                 condition: contains(variables['build.sourceBranch'], 'refs/tags/v')
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
-              - script: ./gradlew --no-daemon publishMavenPublicationToADORepository -PmavenCentralPublishingEnabled=true
+              - script: ./gradlew --no-daemon --init-script .azure-pipelines/network-isolation-feed.init.gradle publishMavenPublicationToADORepository -PmavenCentralPublishingEnabled=true
                 displayName: Publish to local Maven ADO for ESRP
                 condition: not(contains(variables['build.sourceBranch'], 'refs/tags/v'))
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
               - pwsh: |
                   $contents = Get-Content gradle.properties -Raw

--- a/.azure-pipelines/network-isolation-feed.init.gradle
+++ b/.azure-pipelines/network-isolation-feed.init.gradle
@@ -1,0 +1,37 @@
+// Network-isolated CI (CFS): route ALL Gradle dependency and plugin resolution through the
+// authenticated Azure Artifacts feed instead of public repositories (Maven Central / Gradle Plugin
+// Portal). This feed is an upstream-mirroring feed, so it must have Maven Central configured as an
+// upstream source (and the Gradle Plugin Portal upstream, for plugin resolution).
+//
+// Authentication uses the pipeline OAuth token exposed as SYSTEM_ACCESSTOKEN; the Project Collection
+// Build Service identity must have at least Reader access to the feed. This init script is applied via
+// `--init-script` from .azure-pipelines/ci-build.yml and is paired with the MavenAuthenticate@0 task.
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.authentication.http.HttpHeaderAuthentication
+
+final String FEED_URL = 'https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/maven/v1'
+final String ACCESS_TOKEN = System.getenv('SYSTEM_ACCESSTOKEN')
+
+Closure applyFeed = { RepositoryHandler repositories ->
+    repositories.clear()
+    repositories.maven { repo ->
+        repo.url = FEED_URL
+        repo.credentials(HttpHeaderCredentials) { creds ->
+            creds.name = 'Authorization'
+            creds.value = "Bearer ${ACCESS_TOKEN}"
+        }
+        repo.authentication { container -> container.create('header', HttpHeaderAuthentication) }
+    }
+}
+
+// Redirect plugin resolution (settings pluginManagement) to the feed.
+settingsEvaluated { settings ->
+    applyFeed(settings.pluginManagement.repositories)
+}
+
+// Redirect buildscript classpath + project dependency resolution for every project to the feed.
+allprojects { project ->
+    applyFeed(project.buildscript.repositories)
+    applyFeed(project.repositories)
+}


### PR DESCRIPTION
Adds a Gradle init script redirecting dependency/plugin resolution to the authenticated `GraphDeveloperExperiences_Public` feed, wired via `MavenAuthenticate` + `SYSTEM_ACCESSTOKEN` (network isolation / CFS compliance). Needs a pipeline run to validate.