### PR TITLE
Support map-style query parameters (type: object + additionalProperties)

### DIFF
--- a/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
@@ -482,12 +482,10 @@ public class RequestInformation {
             // the variable expansion results in no output". Use "" to send ?key= (empty value).
             @SuppressWarnings("unchecked")
             final Map<Object, Object> rawMap = (Map<Object, Object>) value;
-            final HashMap<String, String> sanitized = new HashMap<>(rawMap.size());
+            final HashMap<String, Object> sanitized = new HashMap<>(rawMap.size());
             for (final Map.Entry<Object, Object> entry : rawMap.entrySet()) {
-                if (entry.getValue() != null) {
-                    sanitized.put(
-                            entry.getKey().toString(),
-                            getSanitizedValues(entry.getValue()).toString());
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    sanitized.put(entry.getKey().toString(), getSanitizedValues(entry.getValue()));
                 }
             }
             return sanitized;

--- a/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
+++ b/components/abstractions/src/main/java/com/microsoft/kiota/RequestInformation.java
@@ -476,6 +476,21 @@ public class RequestInformation {
                 return result;
             }
             return Arrays.asList(values);
+        } else if (value instanceof Map) {
+            // Pre-process map/dictionary values for StdUriTemplate expansion.
+            // Null values are skipped: RFC 6570 §2.3 states "if the value is undefined,
+            // the variable expansion results in no output". Use "" to send ?key= (empty value).
+            @SuppressWarnings("unchecked")
+            final Map<Object, Object> rawMap = (Map<Object, Object>) value;
+            final HashMap<String, String> sanitized = new HashMap<>(rawMap.size());
+            for (final Map.Entry<Object, Object> entry : rawMap.entrySet()) {
+                if (entry.getValue() != null) {
+                    sanitized.put(
+                            entry.getKey().toString(),
+                            getSanitizedValues(entry.getValue()).toString());
+                }
+            }
+            return sanitized;
         } else if (value instanceof ValuedEnum) {
             return ((ValuedEnum) value).getValue();
         } else if (value instanceof UUID) {

--- a/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
@@ -473,6 +473,149 @@ class RequestInformationTest {
         assertEquals("http://localhost/1,2", uri.toString());
     }
 
+    @Test
+    void ExpandsMapQueryParameterAsIndividualKeyValuePairs()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?query*}";
+
+        final GetQueryParameters queryParameters = new GetQueryParameters();
+        queryParameters.query = new HashMap<>();
+        queryParameters.query.put("filter", "equals(published,true)");
+        queryParameters.query.put("sort", "-createdAt");
+
+        // Act
+        requestInfo.addQueryParameters(queryParameters);
+
+        // Assert — RFC 6570 {?query*} expands each map entry as its own key=value pair.
+        // Java's URLEncoder encodes ( → %28, ) → %29, , → %2C.
+        final URI uri = requestInfo.getUri();
+        final String uriStr = uri.toString();
+        assertTrue(uriStr.contains("filter=equals%28published%2Ctrue%29"));
+        assertTrue(uriStr.contains("sort=-createdAt"));
+    }
+
+    @Test
+    void SkipsNullValuesWhenExpandingMapQueryParameter()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?query*}";
+
+        final Map<String, String> mapWithNull = new HashMap<>();
+        mapWithNull.put("filter", "equals(published,true)");
+        mapWithNull.put("sort", null);
+
+        // Act
+        requestInfo.addQueryParameter("query", mapWithNull);
+
+        // Assert — null-valued entry is silently dropped
+        final URI uri = requestInfo.getUri();
+        final String uriStr = uri.toString();
+        assertTrue(uriStr.contains("filter=equals%28published%2Ctrue%29"));
+        assertFalse(uriStr.contains("sort"));
+    }
+
+    @Test
+    void DoesNotThrowWhenMapQueryParameterContainsNullValues()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?query*}";
+
+        final Map<String, String> mapWithNull = new HashMap<>();
+        mapWithNull.put("filter", "value");
+        mapWithNull.put("sort", null);
+
+        // Act + Assert — must not throw NullPointerException
+        assertDoesNotThrow(() -> requestInfo.addQueryParameter("query", mapWithNull));
+        final URI uri = assertDoesNotThrow(() -> requestInfo.getUri());
+        assertTrue(uri.toString().contains("filter=value"));
+        assertFalse(uri.toString().contains("sort"));
+    }
+
+    @Test
+    void PreservesEmptyStringValueInMapQueryParameter()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?query*}";
+
+        final Map<String, String> map = new HashMap<>();
+        map.put("filter", "");
+
+        // Act
+        requestInfo.addQueryParameter("query", map);
+
+        // Assert — empty string emits ?filter= (key present, no value)
+        final URI uri = requestInfo.getUri();
+        assertTrue(uri.toString().contains("filter="));
+    }
+
+    @Test
+    void OmitsMapQueryParameterEntirelyWhenAllValuesAreNull()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?query*}";
+
+        final Map<String, String> allNull = new HashMap<>();
+        allNull.put("filter", null);
+        allNull.put("sort", null);
+
+        // Act
+        requestInfo.addQueryParameter("query", allNull);
+
+        // Assert — sanitized map is empty → StdUriTemplate omits the parameter entirely
+        final URI uri = requestInfo.getUri();
+        assertEquals("http://localhost/articles", uri.toString());
+    }
+
+    @Test
+    void OmitsMapQueryParameterEntirelyWhenMapIsEmpty()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?query*}";
+
+        final GetQueryParameters queryParameters = new GetQueryParameters();
+        queryParameters.query = new HashMap<>();
+
+        // Act
+        requestInfo.addQueryParameters(queryParameters);
+
+        // Assert
+        final URI uri = requestInfo.getUri();
+        assertEquals("http://localhost/articles", uri.toString());
+    }
+
+    @Test
+    void MixesMapQueryParameterWithScalarQueryParameters()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?%24top,query*}";
+
+        requestInfo.addQueryParameter("%24top", 5);
+        final Map<String, String> map = new HashMap<>();
+        map.put("filter", "active");
+        requestInfo.addQueryParameter("query", map);
+
+        // Assert
+        final URI uri = requestInfo.getUri();
+        final String uriStr = uri.toString();
+        assertTrue(uriStr.contains("%24top=5"));
+        assertTrue(uriStr.contains("filter=active"));
+    }
+
     public final SerializationWriterFactory createMockSerializationWriterFactory(
             SerializationWriter writer) {
         final SerializationWriterFactory factoryMock = mock(SerializationWriterFactory.class);
@@ -518,6 +661,12 @@ class GetQueryParameters implements QueryParameters {
      */
     @jakarta.annotation.Nullable public PeriodAndDuration[] messageAges;
 
+    /**
+     * Free-form key-value query parameters (type: object + additionalProperties).
+     * Expanded via RFC 6570 {?query*} into individual key=value pairs.
+     */
+    @jakarta.annotation.Nullable public Map<String, String> query;
+
     @jakarta.annotation.Nonnull public Map<String, Object> toQueryParameters() {
         final Map<String, Object> allQueryParams = new HashMap<>();
         allQueryParams.put("%24select", select);
@@ -528,6 +677,7 @@ class GetQueryParameters implements QueryParameters {
         allQueryParams.put("parallelDatasetIds", parallelDatasetIds);
         allQueryParams.put("expandChildren", expandChildren);
         allQueryParams.put("periods", messageAges);
+        allQueryParams.put("query", query);
         return allQueryParams;
     }
 }

--- a/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
+++ b/components/abstractions/src/test/java/com/microsoft/kiota/RequestInformationTest.java
@@ -505,7 +505,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.GET;
         requestInfo.urlTemplate = "http://localhost/articles{?query*}";
 
-        final Map<String, String> mapWithNull = new HashMap<>();
+        final Map<String, Object> mapWithNull = new HashMap<>();
         mapWithNull.put("filter", "equals(published,true)");
         mapWithNull.put("sort", null);
 
@@ -527,7 +527,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.GET;
         requestInfo.urlTemplate = "http://localhost/articles{?query*}";
 
-        final Map<String, String> mapWithNull = new HashMap<>();
+        final Map<String, Object> mapWithNull = new HashMap<>();
         mapWithNull.put("filter", "value");
         mapWithNull.put("sort", null);
 
@@ -546,7 +546,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.GET;
         requestInfo.urlTemplate = "http://localhost/articles{?query*}";
 
-        final Map<String, String> map = new HashMap<>();
+        final Map<String, Object> map = new HashMap<>();
         map.put("filter", "");
 
         // Act
@@ -565,7 +565,7 @@ class RequestInformationTest {
         requestInfo.httpMethod = HttpMethod.GET;
         requestInfo.urlTemplate = "http://localhost/articles{?query*}";
 
-        final Map<String, String> allNull = new HashMap<>();
+        final Map<String, Object> allNull = new HashMap<>();
         allNull.put("filter", null);
         allNull.put("sort", null);
 
@@ -605,7 +605,7 @@ class RequestInformationTest {
         requestInfo.urlTemplate = "http://localhost/articles{?%24top,query*}";
 
         requestInfo.addQueryParameter("%24top", 5);
-        final Map<String, String> map = new HashMap<>();
+        final Map<String, Object> map = new HashMap<>();
         map.put("filter", "active");
         requestInfo.addQueryParameter("query", map);
 
@@ -614,6 +614,34 @@ class RequestInformationTest {
         final String uriStr = uri.toString();
         assertTrue(uriStr.contains("%24top=5"));
         assertTrue(uriStr.contains("filter=active"));
+    }
+
+    @Test
+    void ExpandsMapQueryParameterWithVariedValueTypes()
+            throws IllegalStateException, URISyntaxException {
+        // Arrange
+        final RequestInformation requestInfo = new RequestInformation();
+        requestInfo.httpMethod = HttpMethod.GET;
+        requestInfo.urlTemplate = "http://localhost/articles{?query*}";
+
+        final Map<String, Object> map = new HashMap<>();
+        map.put("top", 10);
+        map.put("active", true);
+        map.put("enumVal", TestEnum.First);
+        map.put("nullVal", null);
+        map.put(null, "ignoredNullKey");
+
+        // Act
+        requestInfo.addQueryParameter("query", map);
+
+        // Assert
+        final URI uri = requestInfo.getUri();
+        final String uriStr = uri.toString();
+        assertTrue(uriStr.contains("top=10"));
+        assertTrue(uriStr.contains("active=true"));
+        assertTrue(uriStr.contains("enumVal=1"));
+        assertFalse(uriStr.contains("nullVal"));
+        assertFalse(uriStr.contains("ignoredNullKey"));
     }
 
     public final SerializationWriterFactory createMockSerializationWriterFactory(
@@ -665,7 +693,7 @@ class GetQueryParameters implements QueryParameters {
      * Free-form key-value query parameters (type: object + additionalProperties).
      * Expanded via RFC 6570 {?query*} into individual key=value pairs.
      */
-    @jakarta.annotation.Nullable public Map<String, String> query;
+    @jakarta.annotation.Nullable public Map<String, Object> query;
 
     @jakarta.annotation.Nonnull public Map<String, Object> toQueryParameters() {
         final Map<String, Object> allQueryParams = new HashMap<>();


### PR DESCRIPTION
Contributes to https://github.com/microsoft/kiota/issues/3800.

Add a Map branch to getSanitizedValues so that plain-object dictionary query parameters are pre-processed before they reach StdUriTemplate.

Without this change, a Map<String, String> value passed through addQueryParameters or addQueryParameter falls through to the else-return branch unchanged.  When the map contains a null value the subsequent call to StdUriTemplate.convertNativeTypes(null) throws a NullPointerException (null.getClass() is called in the fallback throw).

The fix mirrors the kiota-dotnet SanitizeDictionary approach exactly: null-valued entries are dropped (RFC 6570 para 2.3 treats undefined variables as absent), and remaining values are normalised to String via the existing getSanitizedValues pipeline.  The sanitized HashMap<String, String> is returned so StdUriTemplate.isMap/addMapValue can expand it as individual key=value pairs for RFC 6570 {?param*} templates.

The @SuppressWarnings("unchecked") annotation suppresses the unavoidable raw-type cast of Map<Object,Object> -- Java generics are erased at runtime so the cast to the generic Map type is unverifiable by the compiler, but safe because the entries are accessed only as Object.